### PR TITLE
Check mode improvements

### DIFF
--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -77,6 +77,7 @@
         changed_when: false
         failed_when: false
         register: dnf_configured
+        check_mode: no
         args:
             warn: false
 

--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -15,6 +15,7 @@
         poll: 0
         args:
             creates: /var/lib/aide/aide.db.gz
+        when: not ansible_check_mode
   when:
       - rhel8cis_config_aide
       - rhel8cis_rule_1_4_1

--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -6,6 +6,7 @@
         shell: rpm -qa | grep xorg-x11
         register: xorg_x11_installed
         failed_when: xorg_x11_installed.rc >=2
+        check_mode: no
         changed_when: false
 
       - name: "SCORED | 2.2.2 | PATCH | Ensure X Window System is not installed | remove packages if found"

--- a/tasks/section_3/cis_3.4.2.x.yml
+++ b/tasks/section_3/cis_3.4.2.x.yml
@@ -60,6 +60,7 @@
         shell: "nmcli -t connection show | awk -F: '{ if($4){print $4} }' | while read INT; do firewall-cmd --get-active-zones | grep -B1 $INT; done"
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_3_4_2_5_interfacepolicy
 
       - name: "SCORED | 3.4.2.5 | AUDIT | Ensure network interfaces are assigned to appropriate zone | Get list of interfaces and polocies | Show the interface to policy"
@@ -82,6 +83,7 @@
         shell: "firewall-cmd --get-active-zones | awk '!/:/ {print $1}' | while read ZN; do firewall-cmd --list-all --zone=$ZN; done"
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_3_4_2_6_servicesport
 
       - name: "SCORED | 3.4.2.6 | AUDIT | Ensure unnecessary services and ports are not accepted | Show services adn ports"

--- a/tasks/section_3/cis_3.5.yml
+++ b/tasks/section_3/cis_3.5.yml
@@ -6,6 +6,7 @@
         command: rpm -q NetworkManager
         changed_when: false
         failed_when: false
+        check_mode: no
         args:
           warn: no
         register: rhel_08_nmcli_available

--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -49,6 +49,7 @@
         shell: grep GRUB_CMDLINE_LINUX /etc/default/grub | sed 's/.$//'
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_4_1_1_3_grub_cmdline_linux
         
       - name: "SCORED | 4.1.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Replace existing setting"
@@ -82,6 +83,7 @@
         shell: grep GRUB_CMDLINE_LINUX /etc/default/grub | sed 's/.$//'
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_4_1_1_4_grub_cmdline_linux
 
       - name: "SCORED | 4.1.1.4 | PATCH | Ensure audit_backlog_limit is sufficient | Replace existing setting"

--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -2,12 +2,6 @@
 
 - name: "SCORED | 4.1.1.1 | PATCH | Ensure auditd is installed"
   block:
-      - name: "SCORED | 4.1.1.1 | AUDIT | Ensure auditd is installed | Check for auditd packages"
-        command: rpm -q audit audit-libs
-        changed_when: false
-        failed_when: false
-        register: rhel8cis_4_1_1_1_auditdpackages
-
       - name: "SCORED | 4.1.1.1 | PATCH | Ensure auditd is installed | Install auditd packages"
         package:
             name: audit

--- a/tasks/section_4/cis_4.1.x.yml
+++ b/tasks/section_4/cis_4.1.x.yml
@@ -159,6 +159,7 @@
         shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null; done
         changed_when: false
         failed_when: false
+        check_mode: no
         register: priv_procs
 
       - name: "SCORED | 4.1.12 | PATCH | Ensure successful file system mounts are collected"

--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -6,6 +6,7 @@
         shell: 'authselect current | grep "Profile ID: custom/"'
         failed_when: false
         changed_when: false
+        check_mode: no
         register: rhel8cis_5_3_1_profiles
 
       - name: "SCORED | 5.3.1 | AUDIT | Create custom authselect profile | Show profiles"
@@ -32,6 +33,7 @@
         shell: "authselect current"
         failed_when: false
         changed_when: false
+        check_mode: no
         register: rhel8cis_5_3_2_profiles
 
       - name: "SCORED | 5.3.2 | AUDIT | Select authselect profile | Show profiles"
@@ -58,6 +60,7 @@
         shell: "authselect current | grep with-faillock"
         failed_when: false
         changed_when: false
+        check_mode: no
         register: rhel8cis_5_3_3_profiles_faillock
 
       - name: "SCORED | 5.3.3 | AUDIT | Ensure authselect includes with-faillock| Show profiles"

--- a/tasks/section_5/cis_5.5.1.x.yml
+++ b/tasks/section_5/cis_5.5.1.x.yml
@@ -48,6 +48,7 @@
         shell: useradd -D | grep INACTIVE={{ rhel8cis_inactivelock.lock_days }} | cut -f2 -d=
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_5_5_1_4_inactive_settings
 
       - name: "SCORED | 5.5.1.4 | PATCH | Ensure inactive password lock is 30 days or less | Set default inactive setting"
@@ -56,6 +57,7 @@
 
       - name: "AUDIT | 5.5.1.4 | PATCH | Ensure inactive password lock is 30 days or less | Getting user list"
         shell: 'egrep ^[^:]+:[^\!*] /etc/shadow | cut -d: -f1'
+        check_mode: no
         register: rhel_08_5_5_1_4_audit
         changed_when: false
 
@@ -77,12 +79,14 @@
         shell: echo $(($(date --utc --date "$1" +%s)/86400))
         failed_when: false
         changed_when: false
+        check_mode: no
         register: rhel8cis_5_5_1_5_currentUT
 
       - name: "SCORED | 5.5.1.5 | AUDIT | Ensure all users last password change date is in the past | Get list of users with last changed pw date in the future"
         shell: "cat /etc/shadow | awk -F: '{if($3>{{ rhel8cis_5_5_1_5_currentUT.stdout }})print$1}'"
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_5_5_1_5_user_list
 
       - name: "SCORED | 5.5.1.5 | AUDIT | Ensure all users last password change date is in the past | Alert no pw change in the future exist"

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -31,18 +31,21 @@
   block:
       - name: "SCORED | 6.2.3 | AUDIT | Ensure root PATH Integrity | Determine empty value"
         shell: 'echo $PATH | grep ::'
+        check_mode: no
         register: path_colon
         changed_when: False
         failed_when: path_colon.rc == 0
 
       - name: "SCORED | 6.2.3 | AUDIT | Ensure root PATH Integrity | Determin colon end"
         shell: 'echo $PATH | grep :$'
+        check_mode: no
         register: path_colon_end
         changed_when: False
         failed_when: path_colon_end.rc == 0
 
       - name: "SCORED | 6.2.3 | AUDIT | Ensure root PATH Integrity | Determine dot in path"
         shell: "/bin/bash --login -c 'env | grep ^PATH=' | sed -e 's/PATH=//' -e 's/::/:/' -e 's/:$//' -e 's/:/\\n/g'"
+        check_mode: no
         register: dot_in_path
         changed_when: False
         failed_when: '"." in dot_in_path.stdout_lines'
@@ -378,6 +381,7 @@
         shell: 'getent passwd | cut -d: -f1 | sort -n | uniq -d'
         changed_when: false
         failed_when: false
+        check_mode: no
         register: group_group_check
 
       - name: "SCORED | 6.2.18 | AUDIT | Ensure no duplicate group names exist | Print message that no duplicate groups exist"
@@ -403,18 +407,21 @@
         shell: "getent group shadow | cut -d: -f3"
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_shadow_gid
 
       - name: "SCORED | 6.2.19 | AUDIT | Ensure shadow group is empty | Check /etc/group for empty shadow group"
         shell: grep ^shadow:[^:]*:[^:]*:[^:]+ /etc/group
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_empty_shadow
 
       - name: "SCORED | 6.2.19 | AUDIT | Ensure shadow group is empty | Check for users assigned to shadow"
         shell: "getent passwd | awk -F: '$4 == '{{ rhel8cis_shadow_gid.stdout }}' {print $1}'"
         changed_when: false
         failed_when: false
+        check_mode: no
         register: rhel8cis_shadow_passwd
 
       - name: "SCORED | 6.2.19 | AUDIT | Ensure shadow group is empty | Alert shadow group is empty and no users assigned"


### PR DESCRIPTION
Added check_mode: no at appropriate places where variables are registered by shell commands that don't modify the system, so that a -C run doesn't end in error.
Also removed a block that doesn't seem to be needed anymore (ansible_facts.packages is used instead of the registered variable from that block)