### PR TITLE
Fix crypto policy idempotency (CIS 1.10 and 1.11)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -358,7 +358,7 @@ rhel8cis_set_boot_pass: false
 
 # 1.10/1.11 Set crypto policy (LEGACY, DEFAULT, FUTURE, FIPS)
 # Control 1.10 sates not ot use LEGACY and control 1.11 says to use FUTURE or FIPS.
-rhel8cis_crypto_policy: "FIPS"
+rhel8cis_crypto_policy: "FUTURE"
 
 # System network parameters (host only OR host and router)
 rhel8cis_is_router: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,10 @@
   tags:
   - always
 
+- name: Check crypto-policy input
+  assert:
+    that: rhel8cis_crypto_policy in rhel8cis_allowed_crypto_policies
+
 - name: Check rhel7cis_bootloader_password_hash variable has been changed
   assert:
     that: rhel8cis_bootloader_password_hash != 'grub.pbkdf2.sha512.changethispassword'

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -26,6 +26,12 @@
   changed_when: no
   check_mode: no
 
+- name: "PRELIM | Gather system-wide crypto-policy"
+  shell: update-crypto-policies --show
+  register: system_wide_crypto_policy
+  changed_when: no
+  check_mode: no
+
 - name: "PRELIM | Section 4.1 | Configure System Accounting (auditd)"
   package:
     name: audit
@@ -51,7 +57,7 @@
     stat:
       path: /sys/firmware/efi
     register: rhel_08_efi_boot
-        
+
   - name: set fact for legacy or uefi boot
     set_fact:
       rhel8cis_legacy_boot: 'true'

--- a/tasks/section_1/cis_1.10.yml
+++ b/tasks/section_1/cis_1.10.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: "SCORED | 1.10 | PATCH | Ensure system-wide crypto policy is not legacy"
-  shell: "{{ item }}"
-  loop:
-      - update-crypto-policies --set "{{ rhel8cis_crypto_policy }}"
-      - update-crypto-policies
+  shell: |
+      update-crypto-policies --set "{{ rhel8cis_crypto_policy }}"
+      update-crypto-policies
   when:
       - rhel8cis_rule_1_10
+      - system_wide_crypto_policy['stdout'] == 'LEGACY'
   tags:
       - level1-server
       - level1-workstation

--- a/tasks/section_1/cis_1.11.yml
+++ b/tasks/section_1/cis_1.11.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: "SCORED | 1.11 | PATCH | Ensure system-wide crypto policy is FUTURE or FIPS"
-  shell: "{{ item }}"
-  loop:
-      - update-crypto-policies --set "{{ rhel8cis_crypto_policy }}"
-      - update-crypto-policies
+  shell: |
+      update-crypto-policies --set "{{ rhel8cis_crypto_policy }}"
+      update-crypto-policies
   when:
       - rhel8cis_rule_1_11
+      - system_wide_crypto_policy['stdout'] not in rhel8cis_allowed_crypto_policies
   tags:
       - level2-server
       - level2-workstation

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 # vars file for RHEL8-CIS
+rhel8cis_allowed_crypto_policies:
+  - 'FUTURE'
+  - 'FIPS'


### PR DESCRIPTION
This first collects the crypto-policy in use and adjusts where possible.

It also checks whether the input crypto policy is valid (according to CIS), so for now, you can only pick between FIPS and FUTURE.

This PR also makes FUTURE the default, as FIPS can have a lot of unintended side-effects (I can remove that if you want ;-) )