### PR TITLE
use dnf module and rsyslog 4.2.1.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -200,7 +200,7 @@ rhel8cis_rule_4_1_17: true
 rhel8cis_rule_4_2_1_1: true
 rhel8cis_rule_4_2_1_2: true
 rhel8cis_rule_4_2_1_3: true
-rhel8cis_rule_4_2_1_4: false
+rhel8cis_rule_4_2_1_4: true
 rhel8cis_rule_4_2_1_5: true
 rhel8cis_rule_4_2_1_6: true
 rhel8cis_rule_4_2_2_1: true

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -1,9 +1,9 @@
 ---
 # Post tasks
 
-- name: Perform YUM package cleanup
-  command: dnf -y autoremove
+- name: Perform package cleanup
+  - name: Perform DNF package cleanup
+    dnf: 
+      autoremove: yes
   changed_when: no
   ignore_errors: yes
-  tags:
-  - skip_ansible_lint

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -1,9 +1,8 @@
 ---
 # Post tasks
 
-- name: Perform package cleanup
-  - name: Perform DNF package cleanup
-    dnf: 
-      autoremove: yes
+- name: Perform DNF package cleanup
+  dnf: 
+    autoremove: yes
   changed_when: no
   ignore_errors: yes

--- a/tasks/section_4/cis_4.2.1.x.yml
+++ b/tasks/section_4/cis_4.2.1.x.yml
@@ -56,10 +56,9 @@
                 - "{{ rhel_08_4_2_1_4_audit.stdout_lines }}"
 
       - name: "NOTSCORED | 4.2.1.4 | PATCH | Ensure logging is configured | mail.* log setting"
-        lineinfile:
+        blockinfile:
             path: /etc/rsyslog.conf
             state: present
-            regexp: '^mail\.\*(.*)$'
             marker: "# {mark} MAIL LOG SETTINGS (ANSIBLE MANAGED)"
             block: |
               # mail logging additions to meet CIS standards
@@ -72,10 +71,9 @@
         when: rhel8cis_rsyslog_ansibleManaged
 
       - name: "NOTSCORED | 4.2.1.4 | PATCH | Ensure logging is configured | news.crit log setting"
-        lineinfile:
+        blockinfile:
             path: /etc/rsyslog.conf
             state: present
-            regexp: '^news\.\crit(.*)$'
             marker: "# {mark} NEWS LOG SETTINGS (ANSIBLE MANAGED)"
             block: |
               # news logging additions to meet CIS standards
@@ -89,7 +87,6 @@
         blockinfile:
             path: /etc/rsyslog.conf
             state: present
-            regexp: '^news\.\notice(.*)$'
             marker: "# {mark} MISC. LOG SETTINGS (ANSIBLE MANAGED)"
             block: |
               # misc. logging additions to meet CIS standards
@@ -104,7 +101,6 @@
         blockinfile:
             path: /etc/rsyslog.conf
             state: present
-            regexp: '^news\.\notice(.*)$'
             marker: "#{mark} LOCAL LOG SETTINGS (ANSIBLE MANAGED)"
             block: |
               # local log settings


### PR DESCRIPTION
#109 - dnf module instead of command
- thanks to  stefanwb

#112 - rsyslog enabled by default and resolved
- thanks to Wolskie

Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>