### PR TITLE
Updated default values for clientalivecountmax and clientaliveinterval

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -488,8 +488,8 @@ rhel8cis_system_is_log_server: false
 ## Section5 vars
 
 rhel8cis_sshd:
-    clientalivecountmax: 3
-    clientaliveinterval: 300
+    clientalivecountmax: 0
+    clientaliveinterval: 900
     ciphers: "aes256-ctr,aes192-ctr,aes128-ctr"
     macs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
     logingracetime: 60


### PR DESCRIPTION
Signed-off-by: George Nalen <georgen@mindpointgroup.com>

**Overall Review of Changes:**
Adjusted the default values for clientalivecount and clientaliveinterval

**Issue Fixes:**
#139 - CIS Control 5.2.13 incorrect value

**Enhancements:**
None

**How has this been tested?:**
Locally on RHEL8

