### PR TITLE
Remove extra quotes that break check mode

### DIFF
--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -468,7 +468,7 @@
       - name: "6.2.20 | L1 | AUDIT | Ensure all users' home directories exist"
         command: find -H {{ item.0 | quote }} -not -type l -perm /027
         check_mode: false
-        changed_when: rhel_08_6_2_20_patch_audit.stdout "| length > 0"
+        changed_when: rhel_08_6_2_20_patch_audit.stdout | length > 0
         register: rhel_08_6_2_20_patch_audit
         when:
             - ansible_check_mode


### PR DESCRIPTION
**Overall Review of Changes:**
Fixes syntax error causing #141

**Issue Fixes:**
Fixes #141

**How has this been tested?:**
Ran ansible in check mode, worked fine.