### PR TITLE
Swap order of export/readonly TMOUT

### DIFF
--- a/tasks/section_5/cis_5.5.x.yml
+++ b/tasks/section_5/cis_5.5.x.yml
@@ -49,9 +49,9 @@
       block: |
         # Set session timeout - CIS ID RHEL-08-5.4.5
         TMOUT={{ rhel8cis_shell_session_timeout.timeout }}
-        readonly TMOUT
         export TMOUT
-  with_items:
+        readonly TMOUT
+with_items:
       - { dest: "{{ rhel8cis_shell_session_timeout.file }}", state: present }
       - { dest: /etc/profile, state: "{{ (rhel8cis_shell_session_timeout.file == '/etc/profile') | ternary('present', 'absent') }}" }
   when:


### PR DESCRIPTION
Fixes error when running zsh:
"/etc/profile.d/tmout.sh:5: read-only variable: TMOUT"

Overall Review of Changes:
Swapped order of two lines in tasks/section_5/cis_5.5.x.yml

Issue Fixes:
No issue posted. 

How has this been tested?:

Reproduced file by running playbook.
Logged in using zsh, error message is there.
Swapped order, logged in with zsh: No error
Changed shell to bash, logged in: No error.
Swapped order back to (zsh-faulty) original, bash login: no error
Also verified in each step that TMOUT could not be modified using export TMOUT=123