### PR TITLE
Fix section 5.4.x - enforce_for_root

### DIFF
--- a/tasks/section_5/cis_5.4.x.yml
+++ b/tasks/section_5/cis_5.4.x.yml
@@ -24,7 +24,7 @@
             dest: /etc/pam.d/system-auth
             state: present
             regexp: '^password    requisite                                    pam_pwquality.so'
-            line: "password    requisite                                    pam_pwquality.so try_first_pass local_users_only enforce-for-root retry=3 remember={{ rhel8cis_pam_faillock.remember }}"
+            line: "password    requisite                                    pam_pwquality.so try_first_pass local_users_only enforce_for_root retry=3 remember={{ rhel8cis_pam_faillock.remember }}"
             insertbefore: '^#?password ?'
         when:
             - rhel8cis_rule_5_4_1 or
@@ -35,7 +35,7 @@
             dest: /etc/pam.d/password-auth
             state: present
             regexp: '^password    requisite                                    pam_pwquality.so'
-            line: "password    requisite                                    pam_pwquality.so try_first_pass local_users_only enforce-for-root retry=3"
+            line: "password    requisite                                    pam_pwquality.so try_first_pass local_users_only enforce_for_root retry=3"
             insertbefore: '^#?password ?'
         when: rhel8cis_rule_5_4_1
 


### PR DESCRIPTION
**Overall Review of Changes:**
Fix Section 5.4.x typo in PAM configuration `enforce-for-root` -> `enforce_for_root` (see [here](https://linux.die.net/man/8/pam_pwquality)).

**Issue Fixes:**
n/a

**Enhancements:**
n/a

**How has this been tested?:**
The configuration change has been tested.

