### PR TITLE
Allow setting environment for run_audit.sh invocation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -690,6 +690,11 @@ audit_files_url: "some url maybe s3?"
 audit_files: "/var/tmp/{{ benchmark }}-Audit/"
 
 ## Goss configuration information
+# Set correct env for the run_audit.sh script from https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
+audit_run_script_environment:
+    AUDIT_BIN: "{{ audit_bin }}"
+    AUDIT_FILE: 'goss.yml'
+    AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
 # Where the goss configs and outputs are stored
 audit_out_dir: '/var/tmp'
 audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -2,6 +2,7 @@
 
 - name: "Post Audit | Run post_remediation {{ benchmark }} audit"
   shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
+  environment: "{{ audit_run_script_environment|default({}) }}"
   vars:
       warn: false
 

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -86,6 +86,7 @@
 
 - name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
   shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
+  environment: "{{ audit_run_script_environment|default({}) }}"
   vars:
       warn: false
 


### PR DESCRIPTION
Signed-off-by: Pawel Fiuto <pavloos@gmail.com>

**Overall Review of Changes:**
Allow to set [audit_out_dir ](https://github.com/ansible-lockdown/RHEL8-CIS/blob/e1b72903db64398f90da504c479938ad92bd9c6b/defaults/main.yml#L694)to something else than the default /var/tmp

**Issue Fixes:**
#186 

**How has this been tested?:**
It has been tested by setting [audit_out_dir](https://github.com/ansible-lockdown/RHEL8-CIS/blob/c8883b9964f13c02f49e61121734ef678041cc6d/defaults/main.yml#L694) to something other than default value.
