### PR TITLE
Fix flipped conditional in 5.6.2

### DIFF
--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -13,7 +13,7 @@
             - item.id != "sync"
             - item.id != "shutdown"
             - item.id != "halt"
-            - rhel8cis_int_gid | int < item.gid
+            - item.gid < rhel8cis_int_gid | int
             - item.shell != "      /bin/false"
             - item.shell != "      /usr/sbin/nologin"
         loop_control:
@@ -31,7 +31,7 @@
             - item.id != "sync"
             - item.id != "root"
             - item.id != "nfsnobody"
-            - rhel8cis_int_gid | int < item.gid
+            - item.gid < rhel8cis_int_gid | int
             - item.shell != "      /bin/false"
             - item.shell != "      /usr/sbin/nologin"
         loop_control:


### PR DESCRIPTION
Fixes #192.

From the issue:

> **Describe the Issue**
> 6.5.2 has a flipped conditional, and locks out roughly the complement
> of the set it should lock out.
>
> **Expected Behavior**
> System accounts (UID&lt;1000) have shell set to `nologin`, and have a
> locked password in `/etc/shadow`.
>
> **Actual Behavior**
> All accounts except those (well, not counting an off-by-one bug with
> the account 1000) get locked out, but not the onew that are supposed
> to be locked out.
>
> **Control(s) Affected**
> 6.5.2
>
> **Additional Notes**
> As noted in the CIS documentation, `rhel8cis_int_gid` should be parsed
> out of `/etc/login.defs`, not hardcoded.
>
> The CIS docs suggest we should be comparing the `item.uid` of the
> user, not `item.gid`.
>
> Since I'm not aware of the full rationale behind those two points,
> I've excluded those fixes from the PR.

Signed-off-by: Chandler Swift <chandler+pearson@chandlerswift.com>

**Overall Review of Changes:**
A general description of the changes made that are being requested for merge

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

