### PR TITLE
Versioned grub2cfg handler because it works differently in comparison to RHEL7-CIS

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -103,7 +103,7 @@
       name: systemd-journal-upload
       state: restarted
 
-- name: grub2cfg
+- name: rhel8cis_grub2cfg
   command: "grub2-mkconfig -o {{ grub_cfg.stat.lnk_source }}"
   ignore_errors: True
   notify: change_requires_reboot

--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -7,7 +7,7 @@
       owner: root
       group: root
       mode: 0600
-  notify: grub2cfg
+  notify: rhel8cis_grub2cfg
   when:
       - rhel8cis_set_boot_pass
       - rhel8cis_rule_1_4_1

--- a/tasks/section_1/cis_1.6.1.x.yml
+++ b/tasks/section_1/cis_1.6.1.x.yml
@@ -20,7 +20,7 @@
       replace: ''
   register: selinux_grub_patch
   ignore_errors: yes
-  notify: grub2cfg
+  notify: rhel8cis_grub2cfg
   when:
       - rhel8cis_rule_1_6_1_2
   tags:

--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -54,7 +54,7 @@
             path: /etc/default/grub
             regexp: 'audit=.'
             replace: 'audit=1'
-        notify: grub2cfg
+        notify: rhel8cis_grub2cfg
         when: "'audit=' in rhel8cis_4_1_1_3_grub_cmdline_linux.stdout"
 
       - name: "4.1.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Add audit setting if missing"
@@ -62,7 +62,7 @@
             path: /etc/default/grub
             regexp: '^GRUB_CMDLINE_LINUX='
             line: '{{ rhel8cis_4_1_1_3_grub_cmdline_linux.stdout }} audit=1"'
-        notify: grub2cfg
+        notify: rhel8cis_grub2cfg
         when: "'audit=' not in rhel8cis_4_1_1_3_grub_cmdline_linux.stdout"
   when:
       - rhel8cis_rule_4_1_1_3
@@ -89,7 +89,7 @@
             path: /etc/default/grub
             regexp: 'audit_backlog_limit=\d+'
             replace: 'audit_backlog_limit={{ rhel8cis_audit_back_log_limit }}'
-        notify: grub2cfg
+        notify: rhel8cis_grub2cfg
         when: "'audit_backlog_limit=' in rhel8cis_4_1_1_4_grub_cmdline_linux.stdout"
 
       - name: "4.1.1.4 | PATCH | Ensure audit_backlog_limit is sufficient | Add audit_backlog_limit setting if missing"
@@ -97,7 +97,7 @@
             path: /etc/default/grub
             regexp: '^GRUB_CMDLINE_LINUX='
             line: '{{ rhel8cis_4_1_1_4_grub_cmdline_linux.stdout }} audit_backlog_limit={{ rhel8cis_audit_back_log_limit }}"'
-        notify: grub2cfg
+        notify: rhel8cis_grub2cfg
         when: "'audit_backlog_limit=' not in rhel8cis_4_1_1_4_grub_cmdline_linux.stdout"
   when:
       - rhel8cis_rule_4_1_1_4


### PR DESCRIPTION
**Overall Review of Changes:**
I versioned the ```grub2cfg``` handler as it operates differently in comparison to the RHEL7-CIS role and the other version uses a variable that isn't present in the RHEL8-CIS role.

**Issue Fixes:**
#196 

**How has this been tested?:**
I ran this in my lab with 2 systems (one running EL7 and the other EL8) without issues

