### PR TITLE
Added CentOS keys

### DIFF
--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,0 +1,6 @@
+---
+# OS Specific Settings
+
+rpm_gpg_key: /etc/pki/rpm-gpg/RPM-GPG-KEY-{{ ansible_distribution|lower }}official
+rpm_packager: "The CentOS Project"
+rpm_key: "8483C65D"  # found on https://www.centos.org/keys/


### PR DESCRIPTION
**Overall Review of Changes:**
Distribution-specific key information is being kept in `vars/`, this adds Official CentOS key

**Issue Fixes:**
Fixes error when running against CentOS 8 Stream Distribution

**Enhancements:**
Fixes error when running against CentOS 8 Stream Distribution

**How has this been tested?:**
Ran against CentOS 8 Stream Minimal with no errors after this file was added

