### PR TITLE
4.2.3 and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,24 +124,28 @@ default                    : ok=270  changed=23   unreachable=0    failed=0    s
 - reports - This is a protected branch for our scoring reports, no code should ever go here
 - all other branches** - Individual community member branches
 
-## Lifecycle
+## Lifecycle of releases and branches
 
-- devel branch release
-  - Updates - bug fixes PRs etc
+While Remediate and Audit are managed individually some of the content is linked. Ther are occasions where both need updating or just one of them.
 
-    We aim to get the majority merged to devel in approx 2-4 weeks. This maybe expedited if a customer has a requirement.
+As a general rule we try to abide to the following lifecycle process for branches and releases inclduing ansible-galaxy sync updates. Being community we do have direct customer requests
+and requirements will take priority in releases.
 
-- Main branch release
-  - New benchmark version release
+- devel branch
+  - Staging area for bug fixes PRs and new benchmarks.
 
-    Dependant on the number of changes required and customer priorities we aim to carry the initial update in around 4 weeks.
+    We aim to get the majority of PRs merged to devel in 2-4 weeks.
 
-  - merge of devel for updates
+- Main branch
+  - Merge of devel in to main.
 
     This is dependant on the severity and impact of issues closed. Normally a release alignment every 8-12 weeks (sometimes much quicker)
 
-- Audit
-  - This is generally released in alignment with the this remediation role for releases.
+  - New benchmark version release.
+
+    Once a new benchmark has been released by the provider we aim to get to a new tagged release in 2-4 weeks
+
+  - This is also the where the releases are sourced and linked with ansible-galaxy.
 
 ## Community Contribution
 
@@ -174,7 +178,7 @@ This is a community project at its core and will be managed as such. Please prov
 
 Refer to linked below drop us a message for further information
 
-- [lockdown-enterprise](https://www.lockdownenterprise.com)
+- [Lockdown Enterprise](https://www.lockdownenterprise.com)
   - support for individual repository benchmarks
     - advice on how to use and adopt and priority issue adoption
 - [Ansible Counselor](https://www.mindpointgroup.com/cybersecurity-products/ansible-counselor)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Based on [CIS RedHat Enterprise Linux 8 Benchmark v2.0.0 - 02-23-2022 ](https://
 
 ## Join us
 
-On our [Discord Server](https://discord.gg/JFxpSgPFEJ) to ask questions, discuss features, or just chat with other Ansible-Lockdown users
+On our [Discord Server](https://discord.io/ansible-lockdownJ) to ask questions, discuss features, or just chat with other Ansible-Lockdown users
 
 ## Caution(s)
 
@@ -124,6 +124,25 @@ default                    : ok=270  changed=23   unreachable=0    failed=0    s
 - reports - This is a protected branch for our scoring reports, no code should ever go here
 - all other branches** - Individual community member branches
 
+## Lifecycle
+
+- devel branch release
+  - Updates - bug fixes PRs etc
+
+    We aim to get the majority merged to devel in approx 2-4 weeks. This maybe expedited if a customer has a requirement.
+
+- Main branch release
+  - New benchmark version release
+
+    Dependant on the number of changes required and customer priorities we aim to carry the initial update in around 4 weeks.
+
+  - merge of devel for updates
+
+    This is dependant on the severity and impact of issues closed. Normally a release alignment every 8-12 weeks (sometimes much quicker)
+
+- Audit
+  - This is generally released in alignment with the this remediation role for releases.
+
 ## Community Contribution
 
 We encourage you (the community) to contribute to this role. Please read the rules below.
@@ -151,9 +170,16 @@ https://bugs.launchpad.net/cloud-init/+bug/1839899
 
 ## Support
 
-This is a community project at its core and will be managed as such.
+This is a community project at its core and will be managed as such. Please provide as much information as possible and utilise the community [Discord Server](https://discord.io/ansible-lockdown).
 
-If you would are interested in dedicated support to assist or provide bespoke setups
+Refer to linked below drop us a message for further information
 
-- [Ansible Counselor](https://www.mindpointgroup.com/products/ansible-counselor-on-demand-ansible-services-and-consulting/)
-- [Try us out](https://engage.mindpointgroup.com/try-ansible-counselor)
+- [lockdown-enterprise](https://www.lockdownenterprise.com)
+  - support for individual repository benchmarks
+    - advice on how to use and adopt and priority issue adoption
+- [Ansible Counselor](https://www.mindpointgroup.com/cybersecurity-products/ansible-counselor)
+  - support for all available repos and enhanced support around ansible usage
+
+Bespoke automation support - ansible and otrher products
+
+- Please enquire for specific requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,9 +36,6 @@ benchmark: RHEL8-CIS
 # Whether to skip the reboot
 skip_reboot: true
 
-# default value will change to true but wont reboot if not enabled but will error
-change_requires_reboot: false
-
 
 #### Basic external goss audit enablement settings ####
 #### Precise details - per setting can be found at the bottom of this file ####

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -566,6 +566,10 @@ rhel8cis_journald_runtimekeepfree: 100G
 # rhel8cis_journald_MaxFileSec is how long in time to keep log files. Values are Xm, Xh, Xday, Xweek, Xmonth, Xyear, for example 2week is two weeks
 rhel8cis_journald_maxfilesec: 1month
 
+# 4.2.3 logrotate configuration
+# change to true if you wish to change logrotate.d conf files
+allow_logrotate_conf_umask_updates: false
+
 ## Section5 vars
 
 rhel8cis_sshd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -170,6 +170,6 @@
 
 - name: Output Warning count and control IDs affected
   debug:
-    msg: "You have {{ warn_count }} warning that require investigating that are related to the following benchmark ID(s) {{ control_number }}"
+    msg: "You have {{ warn_count }} warning(s) that require investigating that are related to the following benchmark ID(s) {{ control_number }}"
   tags:
       - always

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -167,3 +167,9 @@
       - run_audit
   tags:
       - run_audit
+
+- name: Output Warning count and control IDs affected
+  debug:
+    msg: "You have {{ warn_count }} messages related to the following benchmark ID(s) {{ control_number }}"
+  tags:
+      - always

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -170,6 +170,6 @@
 
 - name: Output Warning count and control IDs affected
   debug:
-    msg: "You have {{ warn_count }} messages related to the following benchmark ID(s) {{ control_number }}"
+    msg: "You have {{ warn_count }} warning that require investigating that are related to the following benchmark ID(s) {{ control_number }}"
   tags:
       - always

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -24,6 +24,14 @@
         when:
             - change_requires_reboot
             - skip_reboot
+
+      - name: "POST | Warning a reboot required but skip option set | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'Reboot Required' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
+        when:
+            - change_requires_reboot
+            - skip_reboot
   tags:
       - grub
       - level1-server
@@ -36,3 +44,9 @@
       - rhel8cis_section4
       - rhel8cis_section5
       - rhel8cis_section6
+
+- name: If Warning count is 0 set fact
+  set_fact:
+      control_number: "Congratulation None Found"
+  when:
+     - warn_count == '0'

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -10,7 +10,7 @@
 
       - name: "1.1.2.1 | PATCH | Ensure /tmp is a separate partition | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.1.2.1' ]"
+            control_number: "{{ control_number }} + [ 'rule_1.1.2.1' ]"
             warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -1,11 +1,30 @@
 ---
 
 - name: "1.1.2.1 | PATCH | Ensure /tmp is a separate partition"
-  debug:
-      msg: "WARNING!! /tmp is not mounted on a separate partition"
+  block:
+      - name: "1.1.2.1 | PATCH | Ensure /tmp is a separate partition | Absent"
+        debug:
+            msg: "Warning!! /tmp is not mounted on a separate partition"
+        when:
+            - required_mount not in mount_names
+
+      - name: "1.1.2.1 | PATCH | Ensure /tmp is a separate partition | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.1.2.1' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
+        when:
+            - required_mount not in mount_names
+
+      - name: "1.1.3.1 | AUDIT | Ensure separate partition exists for /var | Present"
+        debug:
+            msg: "Congratulations: {{ required_mount }} exists."
+        register: var_mount_present
+        when:
+            - required_mount in mount_names
+  vars:
+      required_mount: '/tmp'
   when:
       - rhel8cis_rule_1_1_2_1
-      - ansible_mounts | selectattr('mount', 'match', '^/tmp$') | list | length == 0
   tags:
       - level1-server
       - level1-workstation

--- a/tasks/section_1/cis_1.1.3.x.yml
+++ b/tasks/section_1/cis_1.1.3.x.yml
@@ -12,7 +12,7 @@
 
       - name: "1.1.3.1 | AUDIT | Ensure separate partition exists for /var | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.1.3.1' ]"
+            control_number: "{{ control_number }} + [ 'rule_1.1.3.1' ]"
             warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names

--- a/tasks/section_1/cis_1.1.3.x.yml
+++ b/tasks/section_1/cis_1.1.3.x.yml
@@ -4,9 +4,16 @@
   block:
       - name: "1.1.3.1 | AUDIT | Ensure separate partition exists for /var | Absent"
         debug:
-            msg: "Warning! {{ required_mount }} doesn't exist. This is a manual task"
+            msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
         register: var_mount_absent
         changed_when: var_mount_absent.skipped is undefined
+        when:
+            - required_mount not in mount_names
+
+      - name: "1.1.3.1 | AUDIT | Ensure separate partition exists for /var | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.1.3.1' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names
 

--- a/tasks/section_1/cis_1.1.4.x.yml
+++ b/tasks/section_1/cis_1.1.4.x.yml
@@ -13,7 +13,7 @@
 
       - name: "1.1.4.1 | AUDIT | Ensure separate partition exists for /var/tmp | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.1.4.1' ]"
+            control_number: "{{ control_number }} + [ 'rule_1.1.4.1' ]"
             warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names

--- a/tasks/section_1/cis_1.1.4.x.yml
+++ b/tasks/section_1/cis_1.1.4.x.yml
@@ -5,9 +5,16 @@
   block:
       - name: "1.1.4.1 | AUDIT | Ensure separate partition exists for /var/tmp | Absent"
         debug:
-            msg: "Warning! {{ required_mount }} doesn't exist. This is a manual task"
+            msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
         register: var_tmp_mount_absent
         changed_when: var_tmp_mount_absent.skipped is undefined
+        when:
+            - required_mount not in mount_names
+
+      - name: "1.1.4.1 | AUDIT | Ensure separate partition exists for /var/tmp | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.1.4.1' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names
 

--- a/tasks/section_1/cis_1.1.5.x.yml
+++ b/tasks/section_1/cis_1.1.5.x.yml
@@ -12,7 +12,7 @@
 
       - name: "1.1.5.1 | AUDIT | Ensure separate partition exists for /var/log | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.1.5.1' ]"
+            control_number: "{{ control_number }} + [ 'rule_1.1.5.1' ]"
             warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names

--- a/tasks/section_1/cis_1.1.5.x.yml
+++ b/tasks/section_1/cis_1.1.5.x.yml
@@ -4,11 +4,19 @@
   block:
       - name: "1.1.5.1 | AUDIT | Ensure separate partition exists for /var/log | Absent"
         debug:
-            msg: "Warning! {{ required_mount }} doesn't exist. This is a manual task"
+            msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
         register: var_log_mount_absent
         changed_when: var_log_mount_absent.skipped is undefined
         when:
             - required_mount not in mount_names
+
+      - name: "1.1.5.1 | AUDIT | Ensure separate partition exists for /var/log | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.1.5.1' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
+        when:
+            - required_mount not in mount_names
+
       - name: "1.1.5.1 | AUDIT | Ensure separate partition exists for /var/log | Present"
         debug:
             msg: "Congratulations: {{ required_mount }} exists."

--- a/tasks/section_1/cis_1.1.6.x.yml
+++ b/tasks/section_1/cis_1.1.6.x.yml
@@ -4,11 +4,19 @@
   block:
       - name: "1.1.6.1 | AUDIT | Ensure separate partition exists for /var/log/audit | Absent"
         debug:
-            msg: "Warning! {{ required_mount }} doesn't exist. This is a manual task"
+            msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
         register: var_log_audit_mount_absent
         changed_when: var_log_audit_mount_absent.skipped is undefined
         when:
             - required_mount not in mount_names
+
+      - name: "1.1.6.1 | AUDIT | Ensure separate partition exists for /var/log/audit | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.1.6.1' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
+        when:
+            - required_mount not in mount_names
+
       - name: "1.1.6.1 | AUDIT | Ensure separate partition exists for /var/log/audit | Present"
         debug:
             msg: "Congratulations: {{ required_mount }} exists."

--- a/tasks/section_1/cis_1.1.6.x.yml
+++ b/tasks/section_1/cis_1.1.6.x.yml
@@ -12,7 +12,7 @@
 
       - name: "1.1.6.1 | AUDIT | Ensure separate partition exists for /var/log/audit | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.1.6.1' ]"
+            control_number: "{{ control_number }} + [ 'rule_1.1.6.1' ]"
             warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names

--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -4,11 +4,19 @@
   block:
       - name: "1.1.7.1 | AUDIT | Ensure separate partition exists for /home | Absent"
         debug:
-            msg: "Warning! {{ required_mount }} doesn't exist. This is a manual task"
+            msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
         register: home_mount_absent
         changed_when: home_mount_absent.skipped is undefined
         when:
             - required_mount not in mount_names
+
+      - name: "1.1.7.1 | AUDIT | Ensure separate partition exists for /home | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.1.7.1' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
+        when:
+            - required_mount not in mount_names
+
       - name: "1.1.7.1 | AUDIT | Ensure separate partition exists for /home | Present"
         debug:
             msg: "Congratulations: {{ required_mount }} exists."

--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -12,7 +12,7 @@
 
       - name: "1.1.7.1 | AUDIT | Ensure separate partition exists for /home | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.1.7.1' ]"
+            control_number: "{{ control_number }} + [ 'rule_1.1.7.1' ]"
             warn_count: "{{ warn_count|int + 1 }}"
         when:
             - required_mount not in mount_names

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -80,7 +80,7 @@
 
       - name: "1.2.4 | AUDIT | Ensure package manager repositories are configured | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ 'rule_1.2.4' ]"
+            control_number: "{{ control_number }} + ['rule_1.2.4']"
             warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_1_2_4

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -80,7 +80,7 @@
 
       - name: "1.2.4 | AUDIT | Ensure package manager repositories are configured | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.2.4' ]"
+            control_number: "{{ control_number }} + [ 'rule_1.2.4' ]"
             warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_1_2_4

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -75,8 +75,13 @@
       - name: "1.2.4 | AUDIT | Ensure package manager repositories are configured | Display repo list"
         debug:
             msg:
-                - "Alert! Below are the configured repos. Please review and make sure all align with site policy"
+                - "Warning!! Below are the configured repos. Please review and make sure all align with site policy"
                 - "{{ dnf_configured.stdout_lines }}"
+
+      - name: "1.2.4 | AUDIT | Ensure package manager repositories are configured | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.2.4' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_1_2_4
   tags:

--- a/tasks/section_1/cis_1.6.1.x.yml
+++ b/tasks/section_1/cis_1.6.1.x.yml
@@ -94,8 +94,15 @@
 
       - name: "1.6.1.6 | AUDIT | Ensure no unconfined services exist | Message on unconfined services"
         debug:
-            msg: "Warning! You have unconfined services: {{ rhelcis_1_6_1_6_unconf_services.stdout_lines }}"
+            msg: "Warning!! You have unconfined services: {{ rhelcis_1_6_1_6_unconf_services.stdout_lines }}"
         when: rhelcis_1_6_1_6_unconf_services.stdout | length > 0
+
+      - name: "1.6.1.6 | AUDIT | Ensure no unconfined services exist | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_1.6.1.6 ]"
+            warn_count: "{{ warn_count|int + 1 }}"
+        when: rhelcis_1_6_1_6_unconf_services.stdout | length > 0
+
   when:
       - rhel8cis_rule_1_6_1_6
   tags:

--- a/tasks/section_2/cis_2.4.yml
+++ b/tasks/section_2/cis_2.4.yml
@@ -18,7 +18,7 @@
 
       - name:  "2.4 | AUDIT | Ensure nonessential services are removed or masked | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '2.4' ]"
+            control_number: "{{ control_number }} + [ 'rule_2.4' ]"
             warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_2_4

--- a/tasks/section_2/cis_2.4.yml
+++ b/tasks/section_2/cis_2.4.yml
@@ -18,7 +18,7 @@
 
       - name:  "2.4 | AUDIT | Ensure nonessential services are removed or masked | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ 'rule_2.4' ]"
+            control_number: "{{ control_number }} + ['rule_2.4']"
             warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_2_4

--- a/tasks/section_2/cis_2.4.yml
+++ b/tasks/section_2/cis_2.4.yml
@@ -12,9 +12,14 @@
       - name: "2.4 | AUDIT | Ensure nonessential services are removed or masked | Display list of services"
         debug:
             msg:
-                - "Alert! Below are the list of services, both active and inactive"
+                - "Warning!! Below are the list of services, both active and inactive"
                 - "Please review to make sure all are essential"
                 - "{{ rhel8cis_2_4_services.stdout_lines }}"
+
+      - name:  "2.4 | AUDIT | Ensure nonessential services are removed or masked | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '2.4' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_2_4
   tags:

--- a/tasks/section_3/cis_3.4.1.x.yml
+++ b/tasks/section_3/cis_3.4.1.x.yml
@@ -100,18 +100,23 @@
 
 - name: "3.4.1.6 | AUDIT | Ensure network interfaces are assigned to appropriate zone"
   block:
-      - name: "3.4.1.6 | AUDIT | Ensure network interfaces are assigned to appropriate zone | Get list of interfaces and polocies"
+      - name: "3.4.1.6 | AUDIT | Ensure network interfaces are assigned to appropriate zone | Get list of interfaces and policies"
         shell: "nmcli -t connection show | awk -F: '{ if($4){print $4} }' | while read INT; do firewall-cmd --get-active-zones | grep -B1 $INT; done"
         changed_when: false
         failed_when: false
         check_mode: no
         register: rhel8cis_3_4_1_6_interfacepolicy
 
-      - name: "3.4.1.6 | AUDIT | Ensure network interfaces are assigned to appropriate zone | Get list of interfaces and polocies | Show the interface to policy"
+      - name: "3.4.1.6 | AUDIT | Ensure network interfaces are assigned to appropriate zone | Get list of interfaces and policies | Show the interface to policy"
         debug:
             msg:
-                - "The items below are the policies tied to the interfaces, please correct as needed"
+                - "Warning!! The items below are the policies tied to the interfaces, please correct as needed"
                 - "{{ rhel8cis_3_4_1_6_interfacepolicy.stdout_lines }}"
+
+      - name: "3.4.1.6 | AUDIT | Ensure network interfaces are assigned to appropriate zone | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_3.4.1.6' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_firewall == "firewalld"
       - rhel8cis_rule_3_4_1_6

--- a/tasks/section_3/cis_3.4.2.x.yml
+++ b/tasks/section_3/cis_3.4.2.x.yml
@@ -96,8 +96,16 @@
       - name: "3.4.2.5 | AUDIT | Ensure an nftables table exists | Alert on no tables"
         debug:
             msg:
-                - "Warning! You currently have no nft tables, please review your setup"
+                - "Warning!! You currently have no nft tables, please review your setup"
                 - 'Use the command "nft create table inet <table name>" to create a new table'
+        when:
+            - rhel8cis_3_4_2_5_nft_tables.stdout | length == 0
+            - not rhel8cis_nft_tables_autonewtable
+
+      - name: "3.4.2.5 | AUDIT | Ensure an nftables table exists | Alert on no tables | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_3.4.2.5' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when:
             - rhel8cis_3_4_2_5_nft_tables.stdout | length == 0
             - not rhel8cis_nft_tables_autonewtable

--- a/tasks/section_4/cis_4.2.2.x.yml
+++ b/tasks/section_4/cis_4.2.2.x.yml
@@ -85,7 +85,13 @@
       - name: "4.2.2.2 | AUDIT | Ensure journald service is enabled | Alert on bad status"
         debug:
             msg:
-                - "ALERT! The status of systemd-journald should be static and it is not. Please investigate"
+                - "Warning!! The status of systemd-journald should be static and it is not. Please investigate"
+        when: "'static' not in rhel8cis_4_2_2_2_status.stdout"
+
+      - name: "4.2.2.2 | AUDIT | Ensure journald service is enabled | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '4.2.2.2' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when: "'static' not in rhel8cis_4_2_2_2_status.stdout"
   when:
       - rhel8cis_rule_4_2_2_2
@@ -191,9 +197,13 @@
       - name: "4.2.2.7 | AUDIT | Ensure journald default file permissions configured | Display file settings"
         debug:
             msg:
-                - "Alert! Below are the current default settings for journald, please confirm they align with your site policies"
-                # - "{{ rhel8cis_4_2_2_7_override_settings.stdout_lines }}"
+                - "Warning!! Below are the current default settings for journald, please confirm they align with your site policies"
                 - "{{ (rhel8cis_4_2_2_7_override_status.matched >= 1) | ternary(rhel8cis_4_2_2_7_override_settings.stdout_lines, rhel8cis_4_2_2_7_notoverride_settings.stdout_lines) }}"
+
+      - name: "4.2.2.7 | AUDIT | Ensure journald default file permissions configured | Warn Count"
+        set_fact:
+            control_number: "{{ control_number }} + [ '1.1.2.1' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_4_2_2_7
   tags:

--- a/tasks/section_4/cis_4.2.2.x.yml
+++ b/tasks/section_4/cis_4.2.2.x.yml
@@ -90,7 +90,7 @@
 
       - name: "4.2.2.2 | AUDIT | Ensure journald service is enabled | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '4.2.2.2' ]"
+            control_number: "{{ control_number }} + [ 'rule_4.2.2.2' ]"
             warn_count: "{{ warn_count|int + 1 }}"
         when: "'static' not in rhel8cis_4_2_2_2_status.stdout"
   when:
@@ -202,7 +202,7 @@
 
       - name: "4.2.2.7 | AUDIT | Ensure journald default file permissions configured | Warn Count"
         set_fact:
-            control_number: "{{ control_number }} + [ '1.1.2.1' ]"
+            control_number: "{{ control_number }} + [ 'rule_4.2.2.7' ]"
             warn_count: "{{ warn_count|int + 1 }}"
   when:
       - rhel8cis_rule_4_2_2_7

--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -48,16 +48,18 @@
               when:
                   - rhel8cis_4_2_3_logrotate_conf_files.files | length >= 1
                   - allow_logrotate_conf_umask_updates
+
+            - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | warning logrotate.d conf files"
+              debug:
+                msg: "Warning!! logrotate.d conf file have create mode that will not match CIS requirements upon rotation"
+              when:
+                  - rhel8cis_4_2_3_logrotate_conf_files.files | length >= 1
+                  - not allow_logrotate_conf_umask_updates
             
-            - block:
-                  - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | warning logrotate.d conf files"
-                    debug:
-                        msg: "Warning!! logrotate.d conf file have create mode that will not match CIS requirements upon rotation"
-                  
-                  - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | Set Warning fact"
-                    set_fact:
-                         control_number: "{{ control_number }} + [ 'rule_4.2.3' ]"
-                         warn_count: "{{ warn_count|int + 1 }}"
+            - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | Set Warning fact"
+              set_fact:
+                    control_number: "{{ control_number }} + [ 'rule_4.2.3' ]"
+                    warn_count: "{{ warn_count|int + 1 }}"
               when:
                   - rhel8cis_4_2_3_logrotate_conf_files.files | length >= 1
                   - not allow_logrotate_conf_umask_updates

--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -1,9 +1,66 @@
 ---
 
 - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured"
-  command: find /var/log -type f -exec chmod g-wx,o-rwx "{}" +
-  changed_when: false
-  failed_when: false
+  block:
+      - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | Find log files"
+        find:
+            paths: /var/log
+            recurse: yes
+            patterns: '*.log'
+        register: rhel8cis_4_2_3_logfiles
+
+      - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | Apply permissions to existing logfiles"
+        file:
+            path: "{{ item.path }}"
+            mode: g-w,o-rwx
+        with_items:
+            - "{{ rhel8cis_4_2_3_logfiles.files }}"
+        loop_control:
+            label: "{{ item.path }}"
+
+      - block:
+            - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | Find logrotate conf files"
+              find:
+                  paths: /etc/logrotate.d
+                  contains: '^\s+create 06[5-7][0-7]'
+              register: rhel8cis_4_2_3_logrotate_conf_files
+
+            - debug:
+                msg: "{{ item }}"
+              loop: "{{ rhel8cis_4_2_3_logrotate_conf_files.files }}"
+              loop_control:
+                  label: "{{ item.path }}"
+
+            - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | update logrotate.conf"
+              lineinfile:
+                  path: /etc/logrotate.conf
+                  regexp: '^create'
+                  line: "create 0640"
+
+            - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | update logrotate.d conf files"
+              replace:
+                  path: "{{ item.path }}"
+                  regexp: 'create [0-7][0-7][0-7][0-7]'
+                  replace: 'create'
+              loop: "{{ rhel8cis_4_2_3_logrotate_conf_files.files }}"
+              loop_control:
+                  label: "{{ item.path }}"
+              when:
+                  - rhel8cis_4_2_3_logrotate_conf_files.files | length >= 1
+                  - allow_logrotate_conf_umask_updates
+            
+            - block:
+                  - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | warning logrotate.d conf files"
+                    debug:
+                        msg: "Warning!! logrotate.d conf file have create mode that will not match CIS requirements upon rotation"
+                  
+                  - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | Set Warning fact"
+                    set_fact:
+                         control_number: "{{ control_number }} + [ 'rule_4.2.3' ]"
+                         warn_count: "{{ warn_count|int + 1 }}"
+              when:
+                  - rhel8cis_4_2_3_logrotate_conf_files.files | length >= 1
+                  - not allow_logrotate_conf_umask_updates
   when:
       - rhel8cis_rule_4_2_3
   tags:

--- a/tasks/section_5/cis_5.6.1.x.yml
+++ b/tasks/section_5/cis_5.6.1.x.yml
@@ -101,7 +101,15 @@
 
       - name: "5.6.1.5 | AUDIT | Ensure all users last password change date is in the past | Alert on accounts with pw change in the future"
         debug:
-            msg: "Warning! The following accounts have the last PW change date in the future: {{ rhel8cis_5_6_1_5_user_list.stdout_lines }}"
+            msg: "Warning!! The following accounts have the last PW change date in the future: {{ rhel8cis_5_6_1_5_user_list.stdout_lines }}"
+        when:
+            - rhel8cis_5_6_1_5_user_list.stdout | length > 0
+            - not rhel8cis_futurepwchgdate_autofix
+
+      - name: "5.6.1.5 | AUDIT | Ensure all users last password change date is in the past | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_5.6.1.5' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when:
             - rhel8cis_5_6_1_5_user_list.stdout | length > 0
             - not rhel8cis_futurepwchgdate_autofix

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -20,8 +20,13 @@
             - name: "6.1.1 | AUDIT | Audit system file permissions | Message out alert for package descrepancies"
               debug:
                   msg: |
-                     "Warning! You have some package descrepancies issues.
+                     "Warning!! You have some package descrepancies issues.
                       The file list can be found in {{ rhel8cis_rpm_audit_file }}"
+
+            - name: "6.1.1 | AUDIT | Audit system file permissions | warning count"
+              set_fact:
+                  control_number: "{{ control_number }} + [ 'rule_6.1.1' ]"
+                  warn_count: "{{ warn_count|int + 1 }}"
         when: rhel8cis_6_1_1_packages_rpm.stdout|length > 0
 
       - name: "6.1.1 | AUDIT | Audit system file permissions | Message out no package descrepancies"

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -33,7 +33,13 @@
 
       - name: "6.2.2 | AUDIT | Ensure all groups in /etc/passwd exist in /etc/group | Print warning about users with invalid GIDs missing GID entries in /etc/group"
         debug:
-            msg: "WARNING: The following users have non-existent GIDs (Groups): {{ rhel8cis_6_2_2_passwd_gid_check.stdout_lines | join (', ') }}"
+            msg: "Warning!! The following users have non-existent GIDs (Groups): {{ rhel8cis_6_2_2_passwd_gid_check.stdout_lines | join (', ') }}"
+        when: rhel8cis_6_2_2_passwd_gid_check.stdout is defined
+
+      - name: "6.2.2 | AUDIT | Ensure all groups in /etc/passwd exist in /etc/group | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_6.2.2' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when: rhel8cis_6_2_2_passwd_gid_check.stdout is defined
   when:
       - rhel8cis_rule_6_2_2
@@ -61,7 +67,13 @@
 
       - name: "6.2.3 | AUDIT| Ensure no duplicate UIDs exist | Print warning about users with duplicate UIDs"
         debug:
-            msg: "Warning: The following users have UIDs that are duplicates: {{ rhel8cis_6_2_3_user_uid_check.stdout_lines }}"
+            msg: "Warning!! The following users have UIDs that are duplicates: {{ rhel8cis_6_2_3_user_uid_check.stdout_lines }}"
+        when: rhel8cis_6_2_3_user_uid_check.stdout is defined
+
+      - name: "6.2.3 | AUDIT| Ensure no duplicate UIDs exist | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_6.2.3' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when: rhel8cis_6_2_3_user_uid_check.stdout is defined
   when:
       - rhel8cis_rule_6_2_3
@@ -89,8 +101,15 @@
 
       - name: "6.2.4 | AUDIT | Ensure no duplicate GIDs exist | Print warning about users with duplicate GIDs"
         debug:
-            msg: "Warning: The following groups have duplicate GIDs: {{ rhel8cis_6_2_4_user_user_check.stdout_lines }}"
+            msg: "Warning!! The following groups have duplicate GIDs: {{ rhel8cis_6_2_4_user_user_check.stdout_lines }}"
         when: rhel8cis_6_2_4_user_user_check.stdout is defined
+
+      - name: "6.2.4 | AUDIT | Ensure no duplicate GIDs exist | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_6.2.4' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
+        when: rhel8cis_6_2_4_user_user_check.stdout is defined
+
   when:
       - rhel8cis_rule_6_2_4
   tags:
@@ -117,7 +136,13 @@
 
       - name: "6.2.5 | AUDIT | Ensure no duplicate user names exist | Print warning about users with duplicate User Names"
         debug:
-            msg: "Warning: The following user names are duplicates: {{ rhel8cis_6_2_5_user_username_check.stdout_lines }}"
+            msg: "Warning!! The following user names are duplicates: {{ rhel8cis_6_2_5_user_username_check.stdout_lines }}"
+        when: rhel8cis_6_2_5_user_username_check.stdout is defined
+
+      - name: "6.2.5 | AUDIT | Ensure no duplicate user names exist | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_6.2.5' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when: rhel8cis_6_2_5_user_username_check.stdout is defined
   when:
       - rhel8cis_rule_6_2_5
@@ -146,7 +171,13 @@
 
       - name: "6.2.6 | AUDIT | Ensure no duplicate group names exist | Print warning about users with duplicate group names"
         debug:
-            msg: "Warning: The following group names are duplicates: {{ rhel8cis_6_2_6_group_group_check.stdout_lines }}"
+            msg: "Warning!! The following group names are duplicates: {{ rhel8cis_6_2_6_group_group_check.stdout_lines }}"
+        when: rhel8cis_6_2_6_group_group_check.stdout is not defined
+
+      - name: "6.2.6 | AUDIT | Ensure no duplicate group names exist | warning count"
+        set_fact:
+            control_number: "{{ control_number }} + [ 'rule_6.2.6' ]"
+            warn_count: "{{ warn_count|int + 1 }}"
         when: rhel8cis_6_2_6_group_group_check.stdout is not defined
   when:
       - rhel8cis_rule_6_2_6

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,3 +10,7 @@ rhel8cis_allowed_crypto_policies:
 # default setting, this should not be changed 
 # and is overridden if a task that changed sets the value if required.
 change_requires_reboot: false
+
+# Used to control warning summary
+control_number: "Congratulations None found"
+warn_count: 0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,5 +12,5 @@ rhel8cis_allowed_crypto_policies:
 change_requires_reboot: false
 
 # Used to control warning summary
-control_number: "Congratulations None found"
+control_number: ""
 warn_count: 0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,7 @@ rhel8cis_allowed_crypto_policies:
     - 'DEFAULT'
     - 'FUTURE'
     - 'FIPS'
+
+# default setting, this should not be changed 
+# and is overridden if a task that changed sets the value if required.
+change_requires_reboot: false


### PR DESCRIPTION
**Overall Review of Changes:**
Update to 4.2.3 and standardise the warning messages
added comments around lifecylce of branches

**Enhancements:**
4.2.3 extended across all logrotate files 
Warning message start brought inline 
New Warning count at end of run stating how many and which controls need to be manually reviewed
e.g.
```

TASK [MPG/OS/Linux/REMEDIATE/RHEL8-CIS : Output Warning count and control IDs affected] *************************************************************************************************************************************************
ok: [rhel80_efi] => {
    "msg": "You have 9 warning(s) that require investigating that are related to the following benchmark ID(s)  + ['rule_1.2.4'] + ['rule_2.4'] + [ 'rule_3.4.1.6' ] + [ 'rule_4.2.3' ] + [ 'rule_6.1.1' ] + [ 'rule_6.2.2' ] + [ 'rule_6.2.3' ] + [ 'rule_6.2.4' ] + [ 'rule_6.2.5' ]"
}

PLAY RECAP ************************************************************************************************************************************************************************************************************************************************************
rhel80_efi                 : ok=313  changed=5    unreachable=0    failed=0    skipped=121  rescued=0    ignored=0 
```


**How has this been tested?:**
Manually

