### PR TITLE
Fix for 5.6.2 - Remove unneeded whitespace in when clause

### DIFF
--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -14,8 +14,8 @@
             - item.id != "shutdown"
             - item.id != "halt"
             - item.gid < rhel8uid_interactive_uid_start | int
-            - item.shell != "      /bin/false"
-            - item.shell != "      /usr/sbin/nologin"
+            - item.shell != "/bin/false"
+            - item.shell != "/usr/sbin/nologin"
         loop_control:
             label: "{{ item.id }}"
 
@@ -32,8 +32,8 @@
             - item.id != "root"
             - item.id != "nfsnobody"
             - item.gid < rhel8uid_interactive_uid_start | int
-            - item.shell != "      /bin/false"
-            - item.shell != "      /usr/sbin/nologin"
+            - item.shell != "/bin/false"
+            - item.shell != "/usr/sbin/nologin"
         loop_control:
             label: "{{ item.id }}"
   when:


### PR DESCRIPTION
**Overall Review of Changes:**
Fix a small typo in the `when` clause, leading to unintended changes, breaking idempotence in my case.

**Issue Fixes:**
n/a

**Enhancements:**
n/a

**How has this been tested?:**
Test on local system.
