### PR TITLE
Reworked auditd tasks into a more universal version

### DIFF
--- a/tasks/section_4/cis_4.1.2.x.yml
+++ b/tasks/section_4/cis_4.1.2.x.yml
@@ -1,48 +1,18 @@
 ---
 
-- name: "4.1.2.1 | PATCH | Ensure audit log storage size is configured"
+- name: |
+    4.1.2.1 | PATCH | Ensure audit log storage size is configured
+    4.1.2.2 | PATCH | Ensure audit logs are not automatically deleted
+    4.1.2.3 | PATCH | Ensure system is disabled when audit logs are full
   lineinfile:
       path: /etc/audit/auditd.conf
-      regexp: "^max_log_file( |=)"
-      line: "max_log_file = {{ rhel8cis_max_log_file_size }}"
+      regexp: "^{{ item }}( |=)"
+      line: "{{ item }} = {{ rhel8cis_auditd[item] }}"
+  loop: "{{ rhel8cis_auditd.keys() }}"
   notify: restart auditd
   when:
       - rhel8cis_rule_4_1_2_1
-  tags:
-      - level2-server
-      - level2-workstation
-      - automated
-      - patch
-      - auditd
-      - rule_4.1.2.1
-
-- name: "4.1.2.2 | PATCH | Ensure audit logs are not automatically deleted"
-  lineinfile:
-      path: /etc/audit/auditd.conf
-      regexp: "^max_log_file_action"
-      line: "max_log_file_action = {{ rhel8cis_auditd['max_log_file_action'] }}"
-  notify: restart auditd
-  when:
       - rhel8cis_rule_4_1_2_2
-  tags:
-      - level2-server
-      - level2-workstation
-      - automated
-      - patch
-      - auditd
-      - rule_4.1.2.2
-
-- name: "4.1.2.3 | PATCH | Ensure system is disabled when audit logs are full"
-  lineinfile:
-      path: /etc/audit/auditd.conf
-      regexp: "{{ item.regexp }}"
-      line: "{{ item.line }}"
-  notify: restart auditd
-  with_items:
-      - { regexp: '^admin_space_left_action', line: 'admin_space_left_action = {{ rhel8cis_auditd.admin_space_left_action }}' }
-      - { regexp: '^action_mail_acct', line: 'action_mail_acct = {{ rhel8cis_auditd.action_mail_acct }}' }
-      - { regexp: '^space_left_action', line: 'space_left_action = {{ rhel8cis_auditd.space_left_action }}' }
-  when:
       - rhel8cis_rule_4_1_2_3
   tags:
       - level2-server
@@ -50,4 +20,6 @@
       - automated
       - patch
       - auditd
+      - rule_4.1.2.1
+      - rule_4.1.2.2
       - rule_4.1.2.3


### PR DESCRIPTION
**Overall Review of Changes:**
I reworked the separate tasks that configure different keys for auditd into a version that will allow for easy extensibility.

This can also allow users to use this role as a means to completely configuring auditd (as opposed to 2 roles that want to manage multiple aspects of the same file). 

Also it's almost fully backwards compatible (except that disabling 1 of the original 3 rules now completely disables it) :-)

**Issue Fixes:**
N/A

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

I ran this on my own machine without issues.