### PR TITLE
RHEL8-CIS/tasks/section_6/cis_6.2.x.yml allow /dev/null home directory

### DIFF
--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -332,6 +332,7 @@
   when:
       - item.uid >= rhel8uid_interactive_uid_start|int
       - item.id != 'nobody'
+      - item.dir != '/dev/null
       - rhel8cis_rule_6_2_10
   tags:
       - skip_ansible_lint  # settings found on 6_2_7

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -332,7 +332,7 @@
   when:
       - item.uid >= rhel8uid_interactive_uid_start|int
       - item.id != 'nobody'
-      - item.dir != '/dev/null
+      - item.dir != '/dev/null'
       - rhel8cis_rule_6_2_10
   tags:
       - skip_ansible_lint  # settings found on 6_2_7


### PR DESCRIPTION
**Overall Review of Changes:**
If home directory is set to /dev/null ownership of user home directory is not required.

**Issue Fixes:**
Playbook fail when home directory is set to /dev/null. For RHEL8 this is standard for 'tss' account:
https://access.redhat.com/solutions/6625061

**Enhancements:**
Allow account with home directory pointing to /dev/nul.

**How has this been tested?:**
Rerun playbook against RHEL8

