### PR TITLE
Retype run_audit and rhel8cis_sectionX variables to bool in conditions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,7 @@
 - name: run pre_remediation audit
   import_tasks: pre_remediation_audit.yml
   when:
-      - run_audit
+      - run_audit | bool
   tags:
       - run_audit
 
@@ -131,36 +131,36 @@
 - name: capture /etc/password variables
   import_tasks: parse_etc_password.yml
   when:
-      - rhel8cis_section5 or
-        rhel8cis_section6
+      - rhel8cis_section5 | bool or
+        rhel8cis_section6 | bool
   tags:
       - always
 
 - name: run Section 1 tasks
   import_tasks: section_1/main.yml
-  when: rhel8cis_section1
+  when: rhel8cis_section1 | bool
   tags:
       - rhel8cis_section1
 
 - name: run Section 2 tasks
   import_tasks: section_2/main.yml
-  when: rhel8cis_section2
+  when: rhel8cis_section2 | bool
 
 - name: run Section 3 tasks
   import_tasks: section_3/main.yml
-  when: rhel8cis_section3
+  when: rhel8cis_section3 | bool
 
 - name: run Section 4 tasks
   import_tasks: section_4/main.yml
-  when: rhel8cis_section4
+  when: rhel8cis_section4 | bool
 
 - name: run Section 5 tasks
   import_tasks: section_5/main.yml
-  when: rhel8cis_section5
+  when: rhel8cis_section5 | bool
 
 - name: run Section 6 tasks
   import_tasks: section_6/main.yml
-  when: rhel8cis_section6
+  when: rhel8cis_section6 | bool
 
 - name: run auditd logic
   import_tasks: auditd.yml
@@ -178,7 +178,7 @@
 - name: run post_remediation audit
   import_tasks: post_remediation_audit.yml
   when:
-      - run_audit
+      - run_audit | bool
   tags:
       - run_audit
 
@@ -186,7 +186,7 @@
   debug:
       msg: "{{ audit_results.split('\n') }}"
   when:
-      - run_audit
+      - run_audit | bool
   tags:
       - run_audit
 

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -66,7 +66,7 @@
         when:
             - not goss_available.stat.exists
   when:
-      - run_audit
+      - run_audit | bool
 
 - name: "Pre Audit | Check whether machine is UEFI-based"
   stat:
@@ -81,7 +81,7 @@
       dest: "{{ audit_vars_path }}"
       mode: 0600
   when:
-      - run_audit
+      - run_audit | bool
   tags:
       - goss_template
 


### PR DESCRIPTION
**Enhancements:**
I ran to issue when running `ansible` command and setting variables via `-e` option, i.g. `-e rhel8cis_section2=false`. The `false` value is interpreted as string and non-empty string is evaluated as true. Retyping variables in conditions will fix it. 

**How has this been tested?:**
N/A

