### PR TITLE
Disallow following symlinks in 6.2.9

### DIFF
--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -255,6 +255,7 @@
         file:
             path: "{{ item.0 }}"
             recurse: true
+            follow: false
             mode: a-st,g-w,o-rwx
         register: rhel_08_6_2_9_patch
         when:
@@ -273,6 +274,7 @@
             default: true
             state: present
             recursive: true
+            follow: false
             etype: "{{ item.1.etype }}"
             permissions: "{{ item.1.mode }}"
         when:


### PR DESCRIPTION
**Overall Review of Changes:**
Enforced to not follow symlinks in ansible > 2.5, please see: 
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html
https://docs.ansible.com/ansible/latest/collections/ansible/posix/acl_module.html

**Issue Fixes:**
There is no issue reported, running the playbook found it change chmod in /usr directory files where venv environment exists in user directories. (Not tested) but seems to basically follow symbolic links so if user make symbolic link in his home directory to /usr the playbook change all attributes in /usr directory.

**How has this been tested?:**
Yes seems to be working correctly


