### PR TITLE
Fix linting, adding Molecule scenarios for ubi8 container and WSL2

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
+---
 parseable: true
 quiet: true
 skip_list:

--- a/.yamllint
+++ b/.yamllint
@@ -1,32 +1,31 @@
 ---
-ignore: |
-  tests/
-  molecule/
-  .github/
-  .gitlab-ci.yml
-  *molecule.yml
-
 extends: default
 
+ignore: |
+    tests/
+    molecule/
+    .github/
+    .gitlab-ci.yml
+    *molecule.yml
+
 rules:
-  indentation:
-    # Requiring 4 space indentation
-    spaces: 4
-    # Requiring consistent indentation within a file, either indented or not
-    indent-sequences: consistent
-  #truthy: disable
-  braces:
-    max-spaces-inside: 1
-    level: error
-  brackets:
-    max-spaces-inside: 1
-    level: error
-  line-length: disable
-  key-duplicates: enable
-  new-line-at-end-of-file: enable
-  new-lines:
-    type: unix
-  trailing-spaces: enable
-  truthy:
-    allowed-values: ['true', 'false']
-    check-keys: true
+    indentation:
+        # Requiring 4 space indentation
+        spaces: 4
+        # Requiring consistent indentation within a file, either indented or not
+        indent-sequences: consistent
+    braces:
+        max-spaces-inside: 1
+        level: error
+    brackets:
+        max-spaces-inside: 1
+        level: error
+    line-length: disable
+    key-duplicates: enable
+    new-line-at-end-of-file: enable
+    new-lines:
+        type: unix
+    trailing-spaces: enable
+    truthy:
+        allowed-values: ['true', 'false']
+        check-keys: false

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ ok: [default] => {
 }
 
 PLAY RECAP *******************************************************************************************************************************************
-default                    : ok=270  changed=23   unreachable=0    failed=0    skipped=140  rescued=0    ignored=0  
+default                    : ok=270  changed=23   unreachable=0    failed=0    skipped=140  rescued=0    ignored=0
 ```
 
 ## Branches
@@ -164,6 +164,26 @@ uses:
 - ansible collections - pulls in the latest version based on requirements file
 - runs the audit using the devel branch
 - This is an automated test that occurs on pull requests into devel
+
+
+## Local Testing
+
+Molecule can be used to work on this role and test in distinct _scenarios_.
+
+**examples**
+
+```bash
+molecule test -s default
+molecule converge -s wsl -- --check
+```
+
+local testing uses:
+- ansible 2.13.3
+- molecule 4.0.1
+- molecule-docker 2.0.0
+- molecule-podman 2.0.2
+- molecule-vagrant 1.0.0
+- molecule-azure 0.5.0
 
 ## known-issues
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -579,7 +579,7 @@ rhel8cis_pam_faillock:
     attempts: 5
     interval: 900
     unlock_time: 900
-    fail_for_root: no  # noqa yaml[truthy]
+    fail_for_root: 'no'
     remember: 5
     pwhash: sha512
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,30 @@
+---
+# This is a playbook to test the tasks.
+- name: Converge
+  hosts: all
+  gather_facts: true
+
+  vars:
+    role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    ansible_user: root
+    system_is_container: true
+    rhel8cis_selinux_disable: true
+    rhel8cis_rule_5_3_4: false
+    rhel8cis_rule_1_1_10: false
+    rhel8cis_rsyslog_ansiblemanaged: false
+    rhel8cis_rule_3_4_1_3: false
+    rhel8cis_rule_3_4_1_4: false
+    rhel8cis_rule_4_1_1_1: false
+    rhel8cis_rule_4_1_1_2: false
+    rhel8cis_rule_4_1_1_3: false
+    rhel8cis_rule_4_1_1_4: false
+    rhel8cis_rule_4_2_1_2: false
+    rhel8cis_rule_4_2_1_4: false
+    rhel8cis_rule_5_1_1: false
+
+  pre_tasks:
+  tasks:
+    - name: "Include tasks"
+      ansible.builtin.include_role:
+        name: "{{ role_name }}"
+

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,34 @@
+---
+# Molecule configuration
+# https://molecule.readthedocs.io/en/latest/
+
+driver:
+  name: docker
+
+platforms:
+  - name: ubi8
+    image: registry.access.redhat.com/ubi8/ubi-init
+    pre_build_image: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    command: "/usr/sbin/init"
+    capabilities:
+      - SYS_ADMIN
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      callbacks_enabled: profile_tasks, timer
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+
+verifier:
+  name: ansible
+

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  vars:
+    role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+
+  tasks:
+    - name: "Include verify tasks"
+      ansible.builtin.include_role:
+        name: "{{ role_name }}"
+        tasks_from: verify

--- a/molecule/wsl/converge.yml
+++ b/molecule/wsl/converge.yml
@@ -1,0 +1,27 @@
+---
+# This is a playbook to test the tasks.
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    ansible_user: "{{ lookup('env', 'USER') }}"
+    system_is_container: true
+    rhel8cis_selinux_disable: true
+    role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    rhel8cis_rule_5_3_4: false
+    rhel8cis_rule_1_1_10: false
+    rhel8cis_rsyslog_ansiblemanaged: false
+    rhel8cis_rule_3_4_1_3: false
+    rhel8cis_rule_3_4_1_4: false
+    rhel8cis_rule_4_2_1_2: false
+    rhel8cis_rule_4_2_1_4: false
+    rhel8cis_rule_5_1_1: false
+
+  pre_tasks:
+  tasks:
+    - name: "Include tasks"
+      ansible.builtin.include_role:
+        name: "{{ role_name }}"
+

--- a/molecule/wsl/molecule.yml
+++ b/molecule/wsl/molecule.yml
@@ -1,0 +1,29 @@
+---
+# Molecule configuration
+# https://molecule.readthedocs.io/en/latest/
+
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: localhost
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      callbacks_enabled: profile_tasks, timer
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+
+verifier:
+  name: ansible
+

--- a/molecule/wsl/verify.yml
+++ b/molecule/wsl/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  vars:
+    role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+
+  tasks:
+    - name: "Include verify tasks"
+      ansible.builtin.include_role:
+        name: "{{ role_name }}"
+        tasks_from: verify


### PR DESCRIPTION
**Overall Review of Changes:**

Adding Molecule scenario's to be able to work with this role using containers and Windows Subsystem Linux.

**Issue Fixes:**


**Enhancements:**
- Added `requirements.txt`
- The `.yamllint` config file complies with `yamllint`. (Champagne!)
- `'no'` is a literal value, not a Boolean.
- `.ansible-lint` is yamllinted

**How has this been tested?:**

```bash
python3 -m venv ~/py3
source ~/py3/bin/activate
python3 -m pip install --upgrade pip
pip3 install wheel
pip3 install -r requirements.txt
molecule lint
molecule converge
molecule converge -s wsl -- --check
```
