### PR TITLE
Feature: molecule verify -s localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Molecule can be used to work on this role and test in distinct _scenarios_.
 ```bash
 molecule test -s default
 molecule converge -s wsl -- --check
+molecule verify -s localhost
 ```
 
 local testing uses:

--- a/molecule/localhost/converge.yml
+++ b/molecule/localhost/converge.yml
@@ -1,0 +1,18 @@
+---
+# This is a playbook to test the tasks.
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    ansible_user: "{{ lookup('env', 'USER') }}"
+    role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    rhel8cis_rule_5_3_4: false
+
+  pre_tasks:
+  tasks:
+    - name: "Include tasks"
+      ansible.builtin.include_role:
+        name: "{{ role_name }}"
+

--- a/molecule/localhost/molecule.yml
+++ b/molecule/localhost/molecule.yml
@@ -1,0 +1,30 @@
+---
+# Molecule configuration
+# https://molecule.readthedocs.io/en/latest/
+
+driver:
+  name: delegated
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+platforms:
+  - name: localhost
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      stdout_callback: yaml
+      callbacks_enabled: profile_tasks, timer
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+
+verifier:
+  name: ansible
+

--- a/molecule/localhost/verify.yml
+++ b/molecule/localhost/verify.yml
@@ -1,0 +1,14 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  become: true
+
+  vars:
+    role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+
+  tasks:
+    - name: "Include verify tasks"
+      ansible.builtin.include_role:
+        name: "{{ role_name }}"
+        tasks_from: verify

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Install openscap
+  ansible.builtin.dnf:
+      state: present
+      name:
+          - openscap-scanner
+          - scap-security-guide
+
+- name: Run CIS oscap scan and create /tmp/report.html
+  ansible.builtin.command:
+      oscap xccdf eval \
+          --report /tmp/report.html
+          --profile cis
+          --fetch-remote-resources
+          /usr/share/xml/scap/ssg/content/ssg-almalinux8-ds.xml
+  changed_when: true
+  no_log: false
+  ignore_errors: true


### PR DESCRIPTION
**Overall Review of Changes:**

Adding a scenario for molecule to allow standalone use of this role to harden _localhost_.

Usage:

```bash
pip install molecule
cd RHEL8-CIS
molecule converge -s localhost
```

Audit:

```bash
pip install molecule
cd RHEL8-CIS
molecule verify -s localhost
```

**Enhancements:**
Harden the machine you're logged onto.

**How has this been tested?:**

Create a machine in Hyper-V/VirtualBox with [https://github.com/bbaassssiiee/provisioning](https://github.com/bbaassssiiee/provisioning)

```bash
make hyperv-image hyperv-box
vagrant up
vagrant scp :/tmp/report.html .
```

