### PR TITLE
Enable adding multiple users to sugroup via a loop

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -607,7 +607,7 @@ rhel8cis_sudo_timestamp_timeout: 15
 # rhel8cis_sugroup: sugroup  # change accordingly wheel is default
 
 # wheel users list
-rhel8cis_sugroup_users: "root"
+rhel8cis_sugroup_users: ["root"]
 
 # 5.4.1/5.4.2 Custom authselect profile settings. Settings in place now will fail, they are place holders from the control example
 # Due to the way many multiple options and ways to configure this control needs to be enabled and settings adjusted to minimise risk

--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -122,8 +122,11 @@
 
       - name: "5.3.7 | PATCH | Ensure access to the su command is restricted | wheel group contains root"
         user:
-            name: "{{ rhel8cis_sugroup_users }}"
+            name: "{{ loop_rhel8cis_sugroup_users }}"
             groups: "{{ rhel8cis_sugroup | default('wheel') }}"
+        loop: "{{ rhel8cis_sugroup_users }}"
+        loop_control:
+          loop_var: loop_rhel8cis_sugroup_users
   when:
       - rhel8cis_rule_5_3_7
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Enable user to provide a list of users to add to the rhel_sugroup via a loop.

**Issue Fixes:**
None.

**Enhancements:**
Enable user to provide a list of users to add to the rhel_sugroup via a loop.

**How has this been tested?:**
Tested deployment on several freshly installed RHEL 8.5 and 9 servers.

