### PR TITLE
Fix for #268

### DIFF
--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -32,7 +32,7 @@
   lineinfile:
       path: /etc/sudoers
       regexp: '^Defaults\s+logfile='
-      line: 'Defaults logfile="{{ rhel8cis_sudolog_location }}"'
+      line: 'Defaults logfile={{ rhel8cis_sudolog_location }}'
   when:
       - rhel8cis_rule_5_3_3
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
The clause to define a logfile for sudoers does not need double quotes. Moreover, running an audit reports a finding.

This will create an audit report (see `tasks/verify.yml`):

```sh
      oscap xccdf eval \
          --report /tmp/report.html
          --profile cis
          --fetch-remote-resources
          /usr/share/xml/scap/ssg/content/ssg-almalinux8-ds.xml
```

**Issue Fixes:**
#268 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**

Given an AlmaLinux machine...

```sh
python3 -m pip install --upgrade pip
python3 -m pip install --user molecule
git clone https://github.com/TeamSalvador/RHEL8-CIS.git
cd RHEL8-CIS/
git checkout bugfix/268
molecule converge -s localhost
molecule verify -s localhost
```

[Ensure Sudo Logfile Exists - sudo logfile](file:///report.html#rule-detail-idm45633635379024)

[report.html.zip](https://github.com/ansible-lockdown/RHEL8-CIS/files/11023247/report.html.zip)

