### PR TITLE
Fix for #280

### DIFF
--- a/tasks/section_4/cis_4.2.2.x.yml
+++ b/tasks/section_4/cis_4.2.2.x.yml
@@ -121,8 +121,11 @@
 - name: "4.2.2.4 | PATCH | Ensure journald is configured to write logfiles to persistent disk"
   ansible.builtin.lineinfile:
       path: /etc/systemd/journald.conf
-      regexp: "^#Storage=|^Storage="
+      regexp: 'Storage='
       line: Storage=persistent
+      state: present
+      insertafter: ^#Storage
+      validate: /usr/bin/bash -n %s
   when:
       - rhel8cis_rule_4_2_2_4
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Fixes the task for persistent storage of logfiles.

**Issue Fixes:**
#280 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**

CIS-CAT-PRO pre-, and post-test.

`sudo grep Storage/etc/systemd/journald.conf`

```bash
Storage=persistent
```
Line should not be commented.