### PR TITLE
April23 updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,10 +2,22 @@
 
 ## 1.5.8
 
-- [#278](https://github.com/ansible-lockdown/RHEL8-CIS/issues/278) thanks to @crayeth
+thanks to @crayeth
+
+- [#278](https://github.com/ansible-lockdown/RHEL8-CIS/issues/278) 
   - Added new options to allow ipv6 rules if required although ipv6 disabled
   - ```rhel8cis_ipv6_sysctl_force```  
   - default: true
+
+thanks to @bbaassssiiee
+
+- [#279](https://github.com/ansible-lockdown/RHEL8-CIS/issues/279)
+- [#280](https://github.com/ansible-lockdown/RHEL8-CIS/issues/280)
+- [#281](https://github.com/ansible-lockdown/RHEL8-CIS/issues/281)
+- [#284](https://github.com/ansible-lockdown/RHEL8-CIS/issues/284)
+  - new option to allow manual changes to pamd files without using authconfig
+  - ```rhel8cis_5_4_2_risks```  need sto be set to ACCEPT to run
+  - default: NEVER
 
 ## 1.5.7
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Changes to rhel8CIS
 
+## 1.5.8
+
+- [#278](https://github.com/ansible-lockdown/RHEL8-CIS/issues/278) thanks to @crayeth
+  - Added new options to allow ipv6 rules if required although ipv6 disabled
+  - ```rhel8cis_ipv6_sysctl_force```  
+  - default: true
+
 ## 1.5.7
 
 - lint updates

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -615,6 +615,9 @@ rhel8cis_authselect:
     default_file_to_copy: "sssd --symlink-meta"
     options: with-sudo with-faillock without-nullok
 
+# This needs to be set to ACCEPT manual changes to the pamd files
+rhel8cis_5_4_2_risks: NEVER
+
 # 5.6.1.1
 # 5.6.1.2
 # 5.6.1.3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -602,7 +602,7 @@ rhel8cis_sudolog_location: "/var/log/sudo.log"
 rhel8cis_sudo_timestamp_timeout: 15
 
 # 5.3.7
-# rhel8cis_sugroup: sugroup  # change accordingly wheel is default
+rhel8cis_sugroup: sugroup
 
 # wheel users list
 rhel8cis_sugroup_users: "root"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -430,6 +430,7 @@ rhel8cis_is_router: false
 
 # IPv6 required
 rhel8cis_ipv6_required: true
+rhel8cis_ipv6_sysctl_force: true
 
 # AIDE
 rhel8cis_config_aide: true

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Download audit binary
+- name: Audit Setup | Download audit binary
   ansible.builtin.get_url:
       url: "{{ goss_url }}"
       dest: "{{ audit_bin }}"
@@ -11,7 +11,7 @@
   when:
       - get_goss_file == 'download'
 
-- name: copy audit binary
+- name: Audit Setup | Copy audit binary
   ansible.builtin.copy:
       src: "{{ copy_goss_from_path }}"
       dest: "{{ audit_bin }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,26 +78,6 @@
       - container_discovery
       - always
 
-- name: "check sugroup exists if used"
-  block:
-      - name: "Check su group exists if defined"
-        ansible.builtin.shell: grep -w "{{ rhel8cis_sugroup }}" /etc/group
-        register: sugroup_exists
-        changed_when: false
-        failed_when: sugroup_exists.rc >= 2
-        tags:
-            - skip_ansible_lint
-
-      - name: Check sugroup if defined exists before continuing
-        ansible.builtin.assert:
-            that: sugroup_exists.rc == 0
-            msg: "The variable rhel8cis_sugroup is defined but does not exist please rectify"
-  when:
-      - rhel8cis_sugroup is defined
-      - rhel8cis_rule_5_7
-  tags:
-      - rule_5.7
-
 - name: Include preliminary steps
   ansible.builtin.import_tasks: prelim.yml
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,18 +36,18 @@
 
 - name: "Check password set for {{ ansible_user }}"
   block:
-      - name: Capture current password state of "{{ ansible_user }}"
-        ansible.builtin.shell: "grep {{ ansible_user }} /etc/shadow | awk -F: '{print $2}'"
+      - name: Capture current password state of connecting user"
+        ansible.builtin.shell: "grep {{ ansible_env.SUDO_USER }} /etc/shadow | awk -F: '{print $2}'"
         changed_when: false
         failed_when: false
         check_mode: false
         register: ansible_user_password_set
 
-      - name: "Assert that password set for {{ ansible_user }} and account not locked"
+      - name: "Assert that password set for {{ ansible_env.SUDO_USER }} and account not locked"
         ansible.builtin.assert:
             that: ansible_user_password_set.stdout | length != 0 and ansible_user_password_set.stdout != "!!"
-            fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_user }} has no password set - It can break access"
-            success_msg: "You a password set for the {{ ansible_user }}"
+            fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
+            success_msg: "You a password set for the {{ ansible_env.SUDO_USER }}"
         vars:
             sudo_password_rule: rhel8cis_rule_5_3_4
   when:

--- a/tasks/section_3/cis_3.2.x.yml
+++ b/tasks/section_3/cis_3.2.x.yml
@@ -19,7 +19,7 @@
             reload: true
             ignoreerrors: true
         notify: sysctl flush ipv6 route table
-        when: rhel8cis_ipv6_required
+        when: rhel8cis_ipv6_required or rhel8cis_ipv6_sysctl_force
   when:
       - not rhel8cis_is_router
       - rhel8cis_rule_3_2_1

--- a/tasks/section_3/cis_3.3.x.yml
+++ b/tasks/section_3/cis_3.3.x.yml
@@ -26,7 +26,7 @@
         with_items:
             - { name: net.ipv6.conf.all.accept_source_route, value: 0}
             - { name: net.ipv6.conf.default.accept_source_route, value: 0 }
-        when: rhel8cis_ipv6_required
+        when: rhel8cis_ipv6_required or rhel8cis_ipv6_sysctl_force
   when:
       - rhel8cis_rule_3_3_1
   tags:
@@ -64,7 +64,7 @@
         with_items:
             - { name: net.ipv6.conf.all.accept_redirects, value: 0 }
             - { name: net.ipv6.conf.default.accept_redirects, value: 0 }
-        when: rhel8cis_ipv6_required
+        when: rhel8cis_ipv6_required or rhel8cis_ipv6_sysctl_force
   when:
       - rhel8cis_rule_3_3_2
   tags:
@@ -208,7 +208,7 @@
       - { name: net.ipv6.conf.all.accept_ra, value: 0 }
       - { name: net.ipv6.conf.default.accept_ra, value: 0 }
   when:
-      - rhel8cis_ipv6_required
+      - rhel8cis_ipv6_required or rhel8cis_ipv6_sysctl_force
       - rhel8cis_rule_3_3_9
   tags:
       - level1-server

--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -114,16 +114,24 @@
 
 - name: "5.3.7 | PATCH | Ensure access to the su command is restricted"
   block:
+      - name: "5.3.7 | PATCH | Ensure access to the su command is restricted | Ensure sugroup exists"
+        ansible.builtin.group:
+            name: "{{ rhel8cis_sugroup }}"
+            state: present
+        register: rhel8cis_5_3_7_sugroup
+
+      - name: "5.3.7 | PATCH | Ensure access to the su command is restricted | remove users from group"
+        ansible.builtin.lineinfile:
+            path: /etc/group
+            regexp: '^{{ rhel8cis_sugroup }}(:.:.*:).*$'
+            line: '{{ rhel8cis_sugroup }}\g<1>'
+            backrefs: true
+
       - name: "5.3.7 | PATCH | Ensure access to the su command is restricted | Setting pam_wheel to use_uid"
         ansible.builtin.lineinfile:
             path: /etc/pam.d/su
             regexp: '^(#)?auth\s+required\s+pam_wheel\.so'
-            line: 'auth            required        pam_wheel.so use_uid {% if rhel8cis_sugroup is defined %}group={{ rhel8cis_sugroup }}{% endif %}'
-
-      - name: "5.3.7 | PATCH | Ensure access to the su command is restricted | wheel group contains root"
-        ansible.builtin.user:
-            name: "{{ rhel8cis_sugroup_users }}"
-            groups: "{{ rhel8cis_sugroup | default('wheel') }}"
+            line: 'auth           required        pam_wheel.so use_uid group={{ rhel8cis_sugroup }}'
   when:
       - rhel8cis_rule_5_3_7
   tags:

--- a/tasks/section_5/cis_5.4.x.yml
+++ b/tasks/section_5/cis_5.4.x.yml
@@ -46,6 +46,36 @@
       - name: "5.4.2 | PATCH | Ensure authselect includes with-faillock | Create custom profiles"
         ansible.builtin.shell: "authselect select custom/{{ rhel8cis_authselect['custom_profile_name'] }} with-faillock"
         when: rhel8cis_authselect_custom_profile_select
+
+      - name: 5.4.2 | PATCH | Ensure authselect includes with-faillock | not auth select profile"
+        ansible.builtin.lineinfile:
+            path: "/etc/pam.d/password-auth"
+            regexp: "{{ item.regexp }}"
+            line: "{{ item.line }}"
+            insertbefore: "{{ item.before }}"
+        loop:
+            - { 'regexp': '^auth\s+required\s+pam_faillock.so preauth silent deny=.*unlock_time=.*', 'line': 'auth        required      pam_faillock.so preauth', 'before':'^auth\s+sufficient\s+pam_unix.so try_first_pass'}
+            - { 'regexp': '^auth\s+required\s+pam_faillock.so authfail deny=.*unlock_time=.*', 'line': 'auth        required      pam_faillock.so authfail', 'before':'^auth\s+required\s+pam_deny.so'}
+            - { 'regexp': '^account\s+required\s+pam_faillock.so', 'line': 'account     required      pam_faillock.so', 'before':'^account     required      pam_unix.so'}
+        when:
+            - not rhel8cis_authselect_custom_profile_select
+            - rhel8cis_5_4_2_risks == 'ACCEPT'
+            - ansible_distribution_version >= "8.2"
+
+      - name: 5.4.2 | PATCH | Ensure authselect includes with-faillock | not auth select profile"
+        ansible.builtin.lineinfile:
+            path: "/etc/pam.d/system-auth"
+            regexp: "{{ item.regexp }}"
+            line: "{{ item.line }}"
+            insertbefore: "{{ item.before | default(omit)}}"
+        loop:
+            - { 'regexp': '^auth\s+required\s+pam_faillock.so preauth silent deny=.*unlock_time=.*', 'line':'auth        required      pam_faillock.so preauth silent', 'before':'^auth\s+sufficient\s+pam_unix.so try_first_pass'}
+            - { 'regexp': '^auth\s+required\s+pam_faillock.so authfail deny=.*unlock_time=.*', 'line': 'auth        required      pam_faillock.so authfail', 'before':'^auth\s+required\s+pam_deny.so'}
+            - { 'regexp': '^account\s+required\s+pam_faillock.so', 'line': 'account     required      pam_faillock.so', 'before':'^account     required      pam_unix.so'}
+        when:
+            - not rhel8cis_authselect_custom_profile_select
+            - rhel8cis_5_4_2_risks == 'ACCEPT'
+            - ansible_distribution_version >= "8.2"
   when:
       - rhel8cis_rule_5_4_2
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Address issues and applied updates

**Issue Fixes:**
thanks to @crayeth

- [#278](https://github.com/ansible-lockdown/RHEL8-CIS/issues/278) 
  - Added new options to allow ipv6 rules if required although ipv6 disabled
  - ```rhel8cis_ipv6_sysctl_force```  
  - default: true

thanks to @bbaassssiiee

- [#279](https://github.com/ansible-lockdown/RHEL8-CIS/issues/279)
- [#280](https://github.com/ansible-lockdown/RHEL8-CIS/issues/280)
- [#281](https://github.com/ansible-lockdown/RHEL8-CIS/issues/281)
- [#284](https://github.com/ansible-lockdown/RHEL8-CIS/issues/284)
  - new option to allow manual changes to pamd files without using authconfig
  - ```rhel8cis_5_4_2_risks```  need sto be set to ACCEPT to run
  - default: NEVER

**Enhancements:**
See issues

**How has this been tested?:**
Manually

