### PR TITLE
Fix for 3.1.3 and premediation/postmediation script calls

### DIFF
--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Post Audit | Run post_remediation {{ benchmark }} audit"
-  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path | quote }} -o {{ post_audit_outfile | quote }} -g {{ group_names | quote }}"
   environment: "{{ audit_run_script_environment | default ({}) }}"
   vars:
       warn: false
@@ -18,7 +18,7 @@
 - name: Post Audit | Capture audit data if json format
   block:
       - name: Post Audit |  "capture data {{ post_audit_outfile }}"
-        ansible.builtin.shell: "cat {{ post_audit_outfile }}"
+        ansible.builtin.shell: "cat {{ post_audit_outfile | quote }}"
         register: post_audit
         changed_when: false
 
@@ -33,7 +33,7 @@
 - name: Post Audit | Capture audit data if documentation format
   block:
       - name: "Post Audit | capture data {{ post_audit_outfile }}"
-        ansible.builtin.shell: "tail -2 {{ post_audit_outfile }}"
+        ansible.builtin.shell: "tail -2 {{ post_audit_outfile | quote }}"
         register: post_audit
         changed_when: false
 

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -109,7 +109,7 @@
 - name: Pre Audit | Capture audit data if documentation format
   block:
       - name: "Pre Audit | capture data {{ pre_audit_outfile }}"
-        ansible.builtin.shell: "tail -2 '{{ pre_audit_outfile | quote }}'"
+        ansible.builtin.shell: "tail -2 {{ pre_audit_outfile | quote }}"
         register: pre_audit
         changed_when: false
 

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -86,7 +86,7 @@
       - goss_template
 
 - name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
-  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path | quote }} -o {{ pre_audit_outfile | quote }} -g {{ group_names | quote }}"
   environment: "{{ audit_run_script_environment | default ({}) }}"
   vars:
       warn: false
@@ -94,7 +94,7 @@
 - name: Pre Audit | Capture audit data if json format
   block:
       - name: "Pre Audit | capture data {{ pre_audit_outfile }}"
-        ansible.builtin.shell: "cat {{ pre_audit_outfile }}"
+        ansible.builtin.shell: "cat {{ pre_audit_outfile | quote }}"
         changed_when: false
         register: pre_audit
 
@@ -109,7 +109,7 @@
 - name: Pre Audit | Capture audit data if documentation format
   block:
       - name: "Pre Audit | capture data {{ pre_audit_outfile }}"
-        ansible.builtin.shell: "tail -2 {{ pre_audit_outfile }}"
+        ansible.builtin.shell: "tail -2 '{{ pre_audit_outfile | quote }}'"
         register: pre_audit
         changed_when: false
 

--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -87,7 +87,7 @@
 
       - name: "3.1.3 | PATCH | Ensure DCCP is disabled | blacklist"
         ansible.builtin.lineinfile:
-            path: /etc/modprobe.d/CIS.conf
+            path: /etc/modprobe.d/blacklist.conf
             regexp: "^(#)?blacklist dccp(\\s|$)"
             line: "blacklist dccp"
             create: true


### PR DESCRIPTION
**Overall Review of Changes:**

- after [recent change](https://github.com/ansible-lockdown/RHEL8-CIS-Audit/blob/eb12485ee3d750ed7571d1be0f6d1d4281596a93/run_audit.sh#L105) in run_audit.sh, the pre- and post mediation script would fail when multiple groups are specified.
- the audit check 3.1.3 for dccp blacklist is expecting the change in blacklist.conf

**Issue Fixes:**
n/a

**Enhancements:**
n/a

**How has this been tested?:**
tested by running hardening playbook with premediation / postmediation audit scan.