### PR TITLE
Fix for #273 Allow for a local crypto policy module, for instance for the openSSH server.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -492,7 +492,14 @@ rhel8cis_selinux_policy: targeted
 
 # 1.6 Set crypto policy (LEGACY, DEFAULT, FUTURE, FIPS)
 rhel8cis_crypto_policy: 'DEFAULT'
-# Added module to be loaded - (Allowed options in vars/main.yml - OSPP and AD-SUPPORT)
+
+# 1.6.1 Allowed crypto-policy modules
+rhel8cis_allowed_crypto_policies_modules:
+    - 'AD-SUPPORT'
+    - 'NO-SHA1'
+    - 'OSPP'
+
+# Added module to be loaded
 rhel8cis_crypto_policy_module: ''
 
 # 1.7

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,10 +7,6 @@ rhel8cis_allowed_crypto_policies:
     - 'FUTURE'
     - 'FIPS'
 
-rhel8cis_allowed_crypto_policies_modules:
-    - 'OSPP'
-    - 'AD-SUPPORT'
-
 # default setting, this should not be changed
 # and is overridden if a task that changed sets the value if required.
 reboot_required: false


### PR DESCRIPTION
If changes to the system-wide crypto policy are required to meet local site policy for the openSSH server, these changes should be done with a sub-policy assigned to the system-wide crypto policy.

 The user should implement a .pmod file, and add its basename to `rhel8cis_allowed_crypto_policies_modules`. 

**Overall Review of Changes:**
- Adds the NO-SHA1 policy module.
- Moves `rhel8cis_allowed_crypto_policies_modules` to `defaults/main.yml` instead of `vars/main.yml`.
The role defaults can be overridden by the user's vars.
The role vars are harder to change due to the 21 priority levels of Ansible.


**Issue Fixes:**
#273 

**Enhancements:**
NO-SHA1 is a simple extra.

**How has this been tested?:**
@bbaassssiiee 

