### PR TITLE
Fix for #361

### DIFF
--- a/tasks/section_3/cis_3.4.2.x.yml
+++ b/tasks/section_3/cis_3.4.2.x.yml
@@ -105,7 +105,7 @@
       - rule_3.4.2.2
   ansible.posix.firewalld:
       rich_rule: "{{ item }}"
-      zone: "{{ rhel8cis_default_zone }}"
+      zone: trusted
       permanent: true
       immediate: true
       state: enabled


### PR DESCRIPTION
**Overall Review of Changes:**
Page 423 3.4.2.2 Ensure host based firewall loopback traffic is configured.
The script on page 425 uses the **trusted** zone for the rich_rule.

**Issue Fixes:**
#361

**Enhancements:**


**How has this been tested?:**
OpenSCAP scanner on AlmaLinux 8.9

