### PR TITLE
Fix rule 1.6.1 idempotence; 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,9 @@ benchmark_version: v3.0.0
 # Whether to skip the reboot
 skip_reboot: true
 
+# Modify behavior of changed_when if reboot is pending and skipped to allow idempotency to succeed
+reboot_warning_changed_when: true
+
 ###
 ### Settings for associated Audit role using Goss
 ###

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -23,7 +23,7 @@
             - skip_reboot
         ansible.builtin.debug:
             msg: "Warning!! changes have been made that require a reboot to be implemented but skip reboot was set - Can affect compliance check results"
-        changed_when: true
+        changed_when: reboot_warning_changed_when
 
       - name: "POST | Warning a reboot required but skip option set | warning count"
         when:

--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -18,7 +18,7 @@
 
       - name: "1.6.1 | PATCH | Ensure system-wide crypto policy is not legacy"
         when:
-            - discovered_system_wide_crypto_policy.stdout not in rhel8cis_crypto_policy
+            - rhel8cis_full_crypto_policy not in discovered_system_wide_crypto_policy.stdout
         ansible.builtin.shell: |
             update-crypto-policies --set "{{ rhel8cis_full_crypto_policy }}"
             update-crypto-policies


### PR DESCRIPTION
**Overall Review of Changes:**
* Fix idempotency of rule 1.6.1
* Modify behavior of changed_when if reboot is pending and skipped to allow idempotency to succeed

Changing the behavior of `changed_when` for the final reboot warning allows for users who are checking for changed tasks in their idempotency checks to filter this one out.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
When the remote host is configured as:
```
[mol-admin@d-mol-rysts-1 ~]$ update-crypto-policies --show
DEFAULT:NO-SHA1:NO-SSHCBC:NO-WEAKMAC
```

Rule 1.6.1 (and subsequent rules) no longer have changed tasks:
```
TASK [RHEL8-CIS : 1.6.1 | PATCH | Ensure system-wide crypto policy is not legacy | set_fact] ***

ok: [rhel-8] => changed=false 
  ansible_facts:
    rhel8cis_full_crypto_policy: DEFAULT

TASK [RHEL8-CIS : 1.6.1 | PATCH | Ensure system-wide crypto policy is not legacy] ***

skipping: [rhel-8] => changed=false 
  false_condition: rhel8cis_full_crypto_policy not in discovered_system_wide_crypto_policy.stdout
  skip_reason: Conditional result was False

TASK [RHEL8-CIS : 1.6.2 | PATCH | Ensure system wide crypto policy disables sha1 hash and signature support | crypto_file] ***

skipping: [rhel-8] => changed=false 
  false_condition: '''NO-SHA1'' not in discovered_system_wide_crypto_policy.stdout'
  skip_reason: Conditional result was False

TASK [RHEL8-CIS : 1.6.2 | PATCH | Ensure system wide crypto policy disables sha1 hash and signature support | set crypto policy] ***

skipping: [rhel-8] => changed=false 
  false_condition: '''NO-SHA1'' not in discovered_system_wide_crypto_policy.stdout'
  skip_reason: Conditional result was False

TASK [RHEL8-CIS : 1.6.3 | PATCH | Ensure system wide crypto policy disables cbc for ssh | crypto_file] ***

skipping: [rhel-8] => changed=false 
  false_condition: '''NO-SSHCBC'' not in discovered_system_wide_crypto_policy.stdout'
  skip_reason: Conditional result was False

TASK [RHEL8-CIS : 1.6.3 | PATCH | Ensure system wide crypto policy disables cbc for ssh | set crypto policy] ***

skipping: [rhel-8] => changed=false 
  false_condition: '''NO-SSHCBC'' not in discovered_system_wide_crypto_policy.stdout'
  skip_reason: Conditional result was False

TASK [RHEL8-CIS : 1.6.4 | PATCH | Ensure system wide crypto policy disables cbc for ssh | crypto_file] ***

skipping: [rhel-8] => changed=false 
  false_condition: '''NO-WEAKMAC'' not in discovered_system_wide_crypto_policy.stdout'
  skip_reason: Conditional result was False

TASK [RHEL8-CIS : 1.6.4 | PATCH | Ensure system wide crypto policy disables cbc for ssh | set crypto policy] ***

skipping: [rhel-8] => changed=false 
  false_condition: '''NO-WEAKMAC'' not in discovered_system_wide_crypto_policy.stdout'
  skip_reason: Conditional result was False
  ````

Ansible version:
```
ansible [core 2.16.8.post0]
```
Target remote host:
```
NAME="Red Hat Enterprise Linux"
VERSION="8.10 (Ootpa)"
```

