### PR TITLE
Added a means to allow system users to have a shell

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -738,6 +738,11 @@ rhel8cis_pam_pass_max_days: 365  # Max 365
 rhel8cis_pam_pass_min_days: 7
 rhel8cis_pam_pass_warn_age: 7
 
+## Control 4.5.2.3 - Ensure system accounts are secured | Set nologin
+# The system users on this list are allowed to have a shell (e.g. applications
+# that require a shell to function)
+rhel8cis_system_users_shell: []
+
 ## Set the following to true if you wish to adjust accounts greater than rhel8cis_pass['max_days']
 rhel8cis_set_max_expiry: false
 

--- a/tasks/section_4/cis_4.5.2.x.yml
+++ b/tasks/section_4/cis_4.5.2.x.yml
@@ -54,6 +54,7 @@
       - name: "4.5.2.3 | PATCH | | Ensure system accounts are secured | Set nologin"
         when:
             - item.id not in prelim_interactive_usernames.stdout
+            - item.id not in rhel8cis_system_users_shell
             - "'root' not in item.id"
         ansible.builtin.user:
             name: "{{ item.id }}"


### PR DESCRIPTION
**Overall Review of Changes:**
Basically the same as https://github.com/ansible-lockdown/RHEL9-CIS/pull/253

I ran into the same issue on a RHEL 8 system :-)

**Issue Fixes:**
I didn't report this as an issue

**Enhancements:**
Added `rhel8cis_system_users_shell`, which can be used to allow system users to have a shell when needed.

**How has this been tested?:**
Manually on my test system

