### PR TITLE
extend when clause for parsing passwords

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,7 +152,8 @@
 
 - name: Capture /etc/password variables
   when:
-      - rhel8cis_section5 or
+      - rhel8cis_section4 or
+        rhel8cis_section5 or
         rhel8cis_section6
   tags:
       - always


### PR DESCRIPTION
`rhel8cis_passwd` is also used in the codeblock for control 4.5.2.3 This change makes sure that the var is also filled when only running section 4.

**Overall Review of Changes:**
A general description of the changes made that are being requested for merge

**Issue Fixes:**
fixes #467 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
ran with only `rhel8cis_section4: true` and all other section to false in my own environment.
