### PR TITLE
Ignore comments in /etc/passwd

### DIFF
--- a/tasks/parse_etc_password.yml
+++ b/tasks/parse_etc_password.yml
@@ -3,7 +3,7 @@
 - name: "PRELIM | 5.5.2 | 6.2.7 | 6.2.8 | 6.2.20 | Parse /etc/passwd"
   block:
       - name: "PRELIM | 5.5.2 | 6.2.7 | 6.2.8 | 6.2.20 | Parse /etc/passwd"
-        ansible.builtin.shell: cat /etc/passwd
+        ansible.builtin.shell: cat /etc/passwd | grep -v '^#'
         changed_when: false
         check_mode: false
         register: discovered_passwd_file_audit


### PR DESCRIPTION
**Overall Review of Changes:**
Ignore any comments in `/etc/passwd`

**Issue Fixes:**
Generation of fact `rhel8cis_passwd` fails if `passwd` is not parsed correctly due to comments

**Enhancements:**
None

**How has this been tested?:**
n/a