### PR TITLE
handle interactive user checks when homedir name is not same as username

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,9 @@ skip_reboot: true
 # Modify behavior of changed_when if reboot is pending and skipped to allow idempotency to succeed
 reboot_warning_changed_when: true
 
+# list of dicts of interactive users, filled in during prelim.yml
+prelim_interactive_users: []
+
 ###
 ### Settings for associated Audit role using Goss
 ###

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -14,25 +14,17 @@
   tags:
       - always
   ansible.builtin.shell: >
-      grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1 }'
+      grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1":"$3":"$6 }'
   changed_when: false
-  register: prelim_interactive_usernames
+  check_mode: false
+  register: prelim_interactive_users_raw
 
-- name: "PRELIM | AUDIT | Interactive User accounts home directories"
+- name: "PRELIM | AUDIT | Interactive Users (reformat)"
   tags:
       - always
-  ansible.builtin.shell: >
-      grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $6 }'
-  changed_when: false
-  register: prelim_interactive_users_home
-
-- name: "PRELIM | AUDIT | Interactive UIDs"
-  tags:
-      - always
-  ansible.builtin.shell: >
-      grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $3 }'
-  changed_when: false
-  register: prelim_interactive_uids
+  ansible.builtin.set_fact:
+      prelim_interactive_users: "{{ prelim_interactive_users | default([]) + [dict([('username', item.split(':')[0]), ('uid', item.split(':')[1]), ('home', item.split(':')[2])])] }}"
+  loop: "{{ prelim_interactive_users_raw.stdout_lines }}"
 
 - name: "PRELIM | Discover Interactive UID MIN and MIN from logins.def"
   block:
@@ -192,14 +184,6 @@
   failed_when: false
   check_mode: false
   register: prelim_sudoers_files
-
-- name: "PRELIM | AUDIT | Interactive User accounts home directories"
-  tags:
-      - always
-  ansible.builtin.shell: >
-      grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $6 }'
-  changed_when: false
-  register: prelim_interactive_users_home
 
 - name: "PRELIM | PATCH | Section 5.1 | Configure System Accounting (auditd)"
   when:

--- a/tasks/section_4/cis_4.5.2.x.yml
+++ b/tasks/section_4/cis_4.5.2.x.yml
@@ -53,7 +53,7 @@
   block:
       - name: "4.5.2.3 | PATCH | | Ensure system accounts are secured | Set nologin"
         when:
-            - item.id not in prelim_interactive_usernames.stdout
+            - item.id not in prelim_interactive_users | map(attribute='uid') | list
             - item.id not in rhel8cis_system_users_shell
             - "'root' not in item.id"
         ansible.builtin.user:
@@ -65,7 +65,7 @@
 
       - name: "4.5.2.3 | PATCH | | Ensure system accounts are secured | Lock accounts"
         when:
-            - "item.id not in prelim_interactive_usernames.stdout"
+            - item.id not in prelim_interactive_users | map(attribute='uid') | list
             - "'root' not in item.id"
         ansible.builtin.user:
             name: "{{ item.id }}"

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -338,16 +338,16 @@
   block:
       - name: "6.2.10 | PATCH | Ensure local interactive user home directories exist | Create dir if absent"
         ansible.builtin.file:
-            path: "{{ item }}"
+            path: "{{ item.home }}"
             state: directory
-            owner: "{{ item | basename }}"
-        loop: "{{ prelim_interactive_users_home.stdout_lines }}"
+            owner: "{{ item.username }}"
+        loop: "{{ prelim_interactive_users }}"
 
       - name: "6.2.10 | PATCH | Ensure local interactive user home directories exist | Permissions"
         ansible.builtin.file:
-            path: "{{ item }}"
+            path: "{{ item.home }}"
             mode: 'g-w,o-rwx'
-        loop: "{{ prelim_interactive_users_home.stdout_lines }}"
+        loop: "{{ prelim_interactive_users }}"
         when: not system_is_container
 
 - name: "6.2.11 | PATCH | Ensure local interactive user dot files access is configured"
@@ -374,7 +374,7 @@
         # check_mode: false
         # register: discovered_hidden_files
         ansible.builtin.find:
-            paths: "{{ prelim_interactive_users_home.stdout_lines | list }}"
+            paths: "{{ prelim_interactive_users | map(attribute='home') | list }}"
             file_type: file
             hidden: true
             use_regex: false
@@ -430,8 +430,8 @@
             - name: "6.2.11 | PATCH | Ensure local interactive user dot files access is configured | Changes files ownerships"
               ansible.builtin.file:
                   path: "{{ item.path }}"
-                  owner: "{{ rhel8cis_passwd | selectattr('dir', 'in', prelim_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item.path) | map(attribute='uid') | last }}"
-                  group: "{{ rhel8cis_passwd | selectattr('dir', 'in', prelim_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item.path) | map(attribute='gid') | last }}"
+                  owner: "{{ rhel8cis_passwd | selectattr('dir', 'in', prelim_interactive_users_raw.stdout_lines) | selectattr('dir', 'in', item.path) | map(attribute='uid') | last }}"
+                  group: "{{ rhel8cis_passwd | selectattr('dir', 'in', prelim_interactive_users_raw.stdout_lines) | selectattr('dir', 'in', item.path) | map(attribute='gid') | last }}"
               failed_when: discovered_files_to_change.state not in '[ file, absent ]'
               register: discovered_files_to_change
               with_items: "{{ discovered_hidden_files.files }}"


### PR DESCRIPTION
**Overall Review of Changes:**
Current implementation assumes that the user's homedir has the same name as the user itself, this is not guaranteed. For example: User `postgres` has a homedir of `/var/lib/pgsql`; pgsql != postgres. This PR create a list of dicts of interactive users as variable prelim_interactive_users, and uses that dict in future tasks.

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL8-CIS/blob/cc025a205aa29bd09efd34aa0ecdd1a98219e253/tasks/section_6/cis_6.2.x.yml#L343

This is the incorrect line that is fixed.

**Enhancements:**
n/a

**How has this been tested?:**
Tested with 20 different Rocky 8 servers.

