### PR TITLE
non-destructive tasks should execute in check_mode

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -16,6 +16,7 @@
   ansible.builtin.shell: >
       grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1 }'
   changed_when: false
+  check_mode: false
   register: prelim_interactive_usernames
 
 - name: "PRELIM | AUDIT | Interactive User accounts home directories"
@@ -24,6 +25,7 @@
   ansible.builtin.shell: >
       grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $6 }'
   changed_when: false
+  check_mode: false
   register: prelim_interactive_users_home
 
 - name: "PRELIM | AUDIT | Interactive UIDs"
@@ -32,6 +34,7 @@
   ansible.builtin.shell: >
       grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $3 }'
   changed_when: false
+  check_mode: false
   register: prelim_interactive_uids
 
 - name: "PRELIM | Discover Interactive UID MIN and MIN from logins.def"
@@ -39,11 +42,13 @@
       - name: "PRELIM | Capture UID_MIN information from logins.def"
         ansible.builtin.shell: grep -w "^UID_MIN" /etc/login.defs | awk '{print $NF}'
         changed_when: false
+        check_mode: false
         register: prelim_uid_min_id
 
       - name: "PRELIM | Capture UID_MAX information from logins.def"
         ansible.builtin.shell: grep -w "^UID_MAX" /etc/login.defs | awk '{print $NF}'
         changed_when: false
+        check_mode: false
         register: prelim_uid_max_id
 
       - name: "PRELIM | Set facts for interactive uid/gid"
@@ -123,6 +128,7 @@
       - always
   ansible.builtin.shell: findmnt -kn /dev/shm
   changed_when: false
+  check_mode: false
   failed_when: prelim_dev_shm_present.rc not in [ 0, 1 ]
   register: prelim_dev_shm_present
 
@@ -199,6 +205,7 @@
   ansible.builtin.shell: >
       grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $6 }'
   changed_when: false
+  check_mode: false
   register: prelim_interactive_users_home
 
 - name: "PRELIM | PATCH | Section 5.1 | Configure System Accounting (auditd)"
@@ -214,6 +221,7 @@
 - name: "PRELIM | AUDIT | 5.2.4.x | Ensure audit log files are mode 0640 or less permissive | discover file"
   ansible.builtin.shell: "grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'"
   changed_when: false
+  check_mode: false
   failed_when: prelim_audit_logfile.rc not in [0, 1]
   register: prelim_audit_logfile
   when:
@@ -287,6 +295,7 @@
       - name: "PRELIM | Optional | If IPv6 disable to stop chronyd listening | Check existence"
         ansible.builtin.shell: grep -E "OPTIONS=.*-4" /etc/sysconfig/chronyd
         changed_when: false
+        check_mode: false
         failed_when: prelim_chrony_ipv6_exists.rc not in [ 0, 1]
         register: prelim_chrony_ipv6_exists
 

--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -33,6 +33,10 @@
             src: /var/lib/aide/aide.db.new.gz
             dest: /var/lib/aide/aide.db.gz
             remote_src: true
+        register: aide_db_cp
+        failed_when:
+            - not ansible_check_mode
+            - aide_db_cp.failed
 
 - name: "5.3.2 | PATCH | Ensure filesystem integrity is regularly checked"
   when:
@@ -92,3 +96,7 @@
         /sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
         /sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
       validate: aide -D --config %s
+  register: aide_file_integrity_check
+  failed_when:
+    - not ansible_check_mode
+    - aide_file_integrity_check.failed

--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -98,5 +98,5 @@
       validate: aide -D --config %s
   register: aide_file_integrity_check
   failed_when:
-    - not ansible_check_mode
-    - aide_file_integrity_check.failed
+      - not ansible_check_mode
+      - aide_file_integrity_check.failed


### PR DESCRIPTION
**Overall Review of Changes:**
Ensure that every non-destructive command is executed fully when running in check mode.

**Issue Fixes:**
Running the role in check mode (`-C`) was failing because various non-destructive command/shell tasks were not executing.

**Enhancements:**
n/a

**How has this been tested?:**
Tested on 20 Rocky 8 servers.

