### PR TITLE
4.5.1.3 not idempotent

### DIFF
--- a/tasks/section_4/cis_4.5.1.x.yml
+++ b/tasks/section_4/cis_4.5.1.x.yml
@@ -92,7 +92,7 @@
 
     - name: "4.5.1.3 | AUDIT | Ensure password expiration warning days is 7 or more | capture users not matching"
       ansible.builtin.shell: >
-        "awk -F: '/^[^:]+:[^!*]/ && $6< {{ rhel8cis_pam_pass_warn_age }} {print $1}' /etc/shadow"
+        awk -F: '/^[^:]+:[^!*]/ && $6< {{ rhel8cis_pam_pass_warn_age }} {print $1}' /etc/shadow
       changed_when: false
       failed_when: discovered_users_warn_days.rc not in [ 0, 1 ]
       check_mode: false


### PR DESCRIPTION
**Overall Review of Changes:**

`"4.5.1.3 | AUDIT | Ensure password expiration warning days is 7 or more | capture users not matching"` currently capture all users with password, instead of only users with expiration warning delay lower than expected.
Therefore `"4.5.1.3 | PATCH | Ensure password expiration warning days is 7 or more | change users not matching req"` is executed on already compliant users.

This fix update `"4.5.1.3 | AUDIT | Ensure password expiration warning days is 7 or more | capture users not matching"` to capture only not compliant users, like in RHEL9-CIS ( https://github.com/ansible-lockdown/RHEL9-CIS/blob/devel/tasks/section_5/cis_5.4.1.x.yml#L87 )